### PR TITLE
refactor: make loss, embedding, and generator less intricate

### DIFF
--- a/pyannote/audio/callback.py
+++ b/pyannote/audio/callback.py
@@ -49,21 +49,21 @@ class LoggingCallback(Callback):
     log_dir : str
     log : list of tuples, optional
         Defaults to [('train', 'loss')]
-    get_model : func
+    extract_embedding : func
         Function that takes Keras model as input and returns the actual model.
         This is useful for embedding that are not directly optimized by Keras.
         Defaults to identity function.
     """
 
-    def __init__(self, log_dir, log=None, get_model=None):
+    def __init__(self, log_dir, log=None, extract_embedding=None):
         super(LoggingCallback, self).__init__()
 
         # make sure path is absolute
         self.log_dir = os.path.realpath(log_dir)
 
-        if get_model is None:
-            get_model = lambda model: model
-        self.get_model = get_model
+        if extract_embedding is None:
+            extract_embedding = lambda model: model
+        self.extract_embedding = extract_embedding
 
         # create log_dir directory (and subdirectory)
         os.makedirs(self.log_dir)
@@ -106,7 +106,7 @@ class LoggingCallback(Callback):
             return
 
         architecture = self.log_dir + '/architecture.yml'
-        model = self.get_model(self.model)
+        model = self.extract_embedding(self.model)
         yaml_string = model.to_yaml()
         with open(architecture, 'w') as fp:
             fp.write(yaml_string)
@@ -123,7 +123,7 @@ class LoggingCallback(Callback):
 
         # save current weights
         try:
-            model = self.get_model(self.model)
+            model = self.extract_embedding(self.model)
             model.save_weights(current_weights, overwrite=True)
         except Exception as e:
             pass

--- a/pyannote/audio/embedding/base.py
+++ b/pyannote/audio/embedding/base.py
@@ -152,7 +152,7 @@ class SequenceEmbedding(object):
         # callbacks, append them as well. this might be useful.
         for stuff in [generator, optimizer, self.glue]:
             if hasattr(stuff, 'callbacks'):
-                callbacks.append(stuff.callbacks(
+                callbacks.extend(stuff.callbacks(
                     extract_embedding=extract_embedding))
 
         self.model_ = self.glue.build_model(input_shape, design_embedding)

--- a/pyannote/audio/embedding/base.py
+++ b/pyannote/audio/embedding/base.py
@@ -37,24 +37,17 @@ class SequenceEmbedding(object):
 
     Parameters
     ----------
-    loss : pyannote.audio.embedding.losses.Loss
-        `Loss` instance. It is expected to implement the following methods:
-        __call__, design_model, and get_embedding
-    optimizer: str, optional
-        Keras optimizer. Defaults to 'rmsprop'.
-    log_dir: str, optional
-        When provided, log status after each epoch into this directory. This
-        will create several files, including loss plots and weights files.
+    glue : pyannote.audio.embedding.glue.Glue
+        `Glue` instance. It is expected to implement the following methods:
+        loss, build_model, and extract_embedding
 
     See also
     --------
-    pyannote.audio.embedding.losses.Loss for more details on `loss` parameter
+    pyannote.audio.embedding.glue.Glue for more details on `glue` parameter
     """
-    def __init__(self, loss=None, optimizer='rmsprop', log_dir=None):
+    def __init__(self, glue=None):
         super(SequenceEmbedding, self).__init__()
-        self.loss = loss
-        self.optimizer = optimizer
-        self.log_dir = log_dir
+        self.glue = glue
 
     @classmethod
     def from_disk(cls, architecture, weights):
@@ -102,7 +95,7 @@ class SequenceEmbedding(object):
         if weights and os.path.isfile(weights) and not overwrite:
             raise ValueError("File '{weights}' already exists.".format(weights=weights))
 
-        embedding = self.loss.get_embedding(self.model_)
+        embedding = self.glue.extract_embedding(self.model_)
 
         if architecture:
             yaml_string = embedding.to_yaml()
@@ -112,14 +105,18 @@ class SequenceEmbedding(object):
         if weights:
             embedding.save_weights(weights, overwrite=overwrite)
 
-    def fit(self, input_shape, generator,
-            samples_per_epoch, nb_epoch, callbacks=[]):
+    def fit(self, input_shape, design_embedding, generator,
+            samples_per_epoch, nb_epoch, optimizer='rmsprop', log_dir=None):
         """Train the embedding
 
         Parameters
         ----------
         input_shape : (n_frames, n_features) tuple
             Shape of input sequence
+        design_embedding : function or callable
+            This function should take input_shape as input and return a Keras
+            model that takes a sequence as input, and returns the embedding as
+            output.
         generator : iterable
             The output of the generator must be a tuple (inputs, targets) or a
             tuple (inputs, targets, sample_weights). All arrays should contain
@@ -130,23 +127,36 @@ class SequenceEmbedding(object):
             Number of samples to process before going to the next epoch.
         nb_epoch : int
             Total number of iterations on the data
-        callbacks : list, optional
-            List of callbacks to be called during training.
-            Defaults to [LoggingCallback()]
+        optimizer: str, optional
+            Keras optimizer. Defaults to 'rmsprop'.
+        log_dir: str, optional
+            When provided, log status after each epoch into this directory.
+            This will create several files, including loss plots and weights
+            files.
 
         See also
         --------
         keras.engine.training.Model.fit_generator
         """
 
-        if not callbacks and self.log_dir is not None:
-            default_callback = LoggingCallback(
-                self.log_dir, get_model=self.loss.get_embedding)
-            callbacks = [default_callback]
+        callbacks = []
 
-        self.model_ = self.loss.design_model(input_shape)
-        self.model_.compile(optimizer=self.optimizer,
-                            loss=self.loss)
+        extract_embedding = self.glue.extract_embedding
+
+        if self.log_dir is not None:
+            callback = LoggingCallback(
+                self.log_dir, extract_embedding=extract_embedding)
+            callbacks.append(callback)
+
+        # in case the {generator | optimizer | glue} define their own
+        # callbacks, append them as well. this might be useful.
+        for stuff in [generator, optimizer, self.glue]:
+            if hasattr(stuff, 'callbacks'):
+                callbacks.append(stuff.callbacks(
+                    extract_embedding=extract_embedding))
+
+        self.model_ = self.glue.build_model(input_shape, design_embedding)
+        self.model_.compile(optimizer=optimizer, loss=self.glue.loss)
 
         return self.model_.fit_generator(
             generator, samples_per_epoch, nb_epoch,
@@ -168,7 +178,7 @@ class SequenceEmbedding(object):
         embeddings : (n_samples, n_dimensions)
         """
         if not hasattr(self, 'embedding_'):
-            self.embedding_ = self.loss.get_embedding(self.model_)
+            self.embedding_ = self.glue.extract_embedding(self.model_)
 
         return self.embedding_.predict(
             sequences, batch_size=batch_size, verbose=verbose)

--- a/pyannote/audio/embedding/base.py
+++ b/pyannote/audio/embedding/base.py
@@ -143,9 +143,9 @@ class SequenceEmbedding(object):
 
         extract_embedding = self.glue.extract_embedding
 
-        if self.log_dir is not None:
+        if log_dir is not None:
             callback = LoggingCallback(
-                self.log_dir, extract_embedding=extract_embedding)
+                log_dir, extract_embedding=extract_embedding)
             callbacks.append(callback)
 
         # in case the {generator | optimizer | glue} define their own

--- a/pyannote/audio/embedding/glue.py
+++ b/pyannote/audio/embedding/glue.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# The MIT License (MIT)
+
+# Copyright (c) 2016 CNRS
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# AUTHORS
+# Hervé BREDIN - http://herve.niderb.fr
+
+
+class Glue(object):
+    """Glue for sequence embedding training"""
+
+    def __init__(self, **kwargs):
+        super(Glue, self).__init__()
+
+    def loss(self, y_true, y_pred):
+        raise NotImplementedError('')
+
+    def build_model(self, input_shape, design_embedding):
+        """Design the model for which the loss is optimized
+
+        Parameters
+        ----------
+        input_shape: (n_samples, n_features) tuple
+            Shape of input sequences.
+        design_embedding : function or callable
+            This function should take input_shape as input and return a Keras
+            model that takes a sequence as input, and returns the embedding as
+            output.
+
+        Returns
+        -------
+        model : Keras model
+
+        See also
+        --------
+        An example of such a method can be found in `TripletLoss` class
+        """
+        raise NotImplementedError('')
+
+    def extract_embedding(self, from_model):
+        """Extract embedding from internal Keras model
+
+        Parameters
+        ----------
+        from_model : Keras model
+            Current state of the model
+
+        Returns
+        -------
+        embedding : Keras model
+        """
+        return from_model

--- a/pyannote/audio/embedding/triplet_loss/__init__.py
+++ b/pyannote/audio/embedding/triplet_loss/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# The MIT License (MIT)
+
+# Copyright (c) 2016 CNRS
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# AUTHORS
+# Hervé BREDIN - http://herve.niderb.fr

--- a/pyannote/audio/embedding/triplet_loss/generator.py
+++ b/pyannote/audio/embedding/triplet_loss/generator.py
@@ -34,17 +34,22 @@ from pyannote.generators.batch import BaseBatchGenerator
 from pyannote.audio.generators.labels import \
     LabeledFixedDurationSequencesBatchGenerator
 from keras.callbacks import Callback
+from keras.models import model_from_yaml
+from pyannote.audio.embedding.base import SequenceEmbedding
 
 
 class UpdateEmbedding(Callback):
+
     def __init__(self, generator, extract_embedding):
         super(UpdateEmbedding, self).__init__()
         self.generator = generator
         self.extract_embedding = extract_embedding
 
-    def on_batch_begin(self, batch, logs={}):
+    def on_train_begin(self, logs={}):
         self.generator.update(self.model, self.extract_embedding)
 
+    def on_batch_begin(self, batch, logs={}):
+        self.generator.update(self.model, self.extract_embedding)
 
 class TripletGenerator(object):
     """Triplet generator for triplet loss sequence embedding
@@ -65,8 +70,6 @@ class TripletGenerator(object):
         Yaafe feature extraction (e.g. YaafeMFCC instance)
     file_generator: iterable
         File generator (the training set, typically)
-    embedding: SequenceEmbedding
-        Sequence embedding (currently being optimized)
     duration: float, optional
         Sequence duration. Defaults to 3 seconds.
     overlap: float, optional
@@ -83,7 +86,7 @@ class TripletGenerator(object):
         Batch size. Defaults to 32.
     """
 
-    def __init__(self, extractor, file_generator, embedding, margin=0.2,
+    def __init__(self, extractor, file_generator, margin=0.2,
                  duration=3.0, overlap=0.0, normalize=False,
                  per_fold=0, per_label=40, batch_size=32):
 
@@ -91,7 +94,6 @@ class TripletGenerator(object):
 
         self.extractor = extractor
         self.file_generator = file_generator
-        self.embedding = embedding
         self.margin = margin
         self.duration = duration
         self.overlap = overlap
@@ -213,6 +215,7 @@ class TripletGenerator(object):
                 # their embeddings (using current state of embedding network)
                 embeddings = self.embedding.transform(
                     sequences, batch_size=self.batch_size)
+
                 # pairwise squared euclidean distances
                 distances = squareform(pdist(embeddings, metric='sqeuclidean'))
 
@@ -300,8 +303,6 @@ class TripletBatchGenerator(BaseBatchGenerator):
         Yaafe feature extraction (e.g. YaafeMFCC instance)
     file_generator: iterable
         File generator (the training set, typically)
-    sequence_embedding: TripletLossSequenceEmbedding
-        Triplet loss sequence embedding (currently being optimized)
     duration: float, optional
         Sequence duration. Defaults to 3 seconds.
     overlap: float, optional
@@ -316,12 +317,12 @@ class TripletBatchGenerator(BaseBatchGenerator):
     batch_size: int, optional
         Batch size. Defaults to 32.
     """
-    def __init__(self, feature_extractor, file_generator, sequence_embedding,
+    def __init__(self, feature_extractor, file_generator,
                  margin=0.2, duration=3.0, overlap=0.5, normalize=False,
                  per_fold=0, per_label=40, batch_size=32):
 
         self.triplet_generator_ = TripletGenerator(
-            feature_extractor, file_generator, sequence_embedding,
+            feature_extractor, file_generator,
             duration=duration, overlap=overlap, normalize=normalize,
             per_fold=per_fold, per_label=per_label, batch_size=batch_size)
 


### PR DESCRIPTION
- refactor: embedding architecture, optimizer, and `log_dir` are now
passed at `fit` time
- refactor: `get_embedding` is renamed to `extract_embedding`
- refactor: `design_model` is renamed to `build_model`
- refactor: `__call__` is renamed to `loss`
- feat: generators (and optimizers) can now define their own callback
- feat: `TripletGenerator` defines its own `on_batch_begin` update
callback