### PR TITLE
Fix VariableDurationSequences numpy stack: all input arrays must have…

### DIFF
--- a/pyannote/audio/generators/labels.py
+++ b/pyannote/audio/generators/labels.py
@@ -157,9 +157,10 @@ class VariableDurationSequences(PeriodicFeaturesMixin,
 
     def signature(self):
         return (
-            {'type': 'ndarray', 'shape': self.shape},
+            {'type': 'sequences', 'shape': self.shape},
             {'type': 'label'}
         )
+        
 
     def pack_sequence(self, sequences):
         """


### PR DESCRIPTION

Here is the traceback when using VariableDurationSequences

ValueError                                Traceback (most recent call last)
<ipython-input-8-8c2f42db9c6d> in <module>()
----> 1 for x_batch, y_batch in batch_generator.from_file(current_file):
      2     break

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in from_file(self, current_file, incomplete)
    406         for batch in self.__call__(current_file_generator(),
    407                                    infinite=False,
--> 408                                    incomplete=incomplete):
    409             yield batch
    410 

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in __call__(self, file_generator, infinite, robust, incomplete)
    466                 # fixed batch size
    467                 if self.batch_size > 0 and batch_size == self.batch_size:
--> 468                     batch = self._batch_pack(signature_out)
    469                     yield self.postprocess(batch)
    470                     self.batch_ = self._batch_new(signature_out)

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in _batch_pack(self, signature_out, batch)
    275         elif type(signature_out) == tuple:
    276             return tuple(self._batch_pack(_signature_out, batch=_batch)
--> 277                           for _signature_out, _batch in zip(signature_out, batch))
    278 
    279         elif type(signature_out) == dict:

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in <genexpr>(.0)
    275         elif type(signature_out) == tuple:
    276             return tuple(self._batch_pack(_signature_out, batch=_batch)
--> 277                           for _signature_out, _batch in zip(signature_out, batch))
    278 
    279         elif type(signature_out) == dict:

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in _batch_pack(self, signature_out, batch)
    287                 pack_func = getattr(self, 'pack_' + fragment_type,
    288                                     self._passthrough)
--> 289                 return pack_func(batch)
    290 
    291     def _postprocess(self, batch, signature):

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/pyannote/generators/batch.py in pack_ndarray(self, ndarrays)
    253 
    254     def pack_ndarray(self, ndarrays):
--> 255         return np.stack(ndarrays)
    256 
    257     def pack_batch(self, batches):

~/anaconda3/envs/pyannote/lib/python3.6/site-packages/numpy/core/shape_base.py in stack(arrays, axis, out)
    351     shapes = set(arr.shape for arr in arrays)
    352     if len(shapes) != 1:
--> 353         raise ValueError('all input arrays must have the same shape')
    354 
    355     result_ndim = arrays[0].ndim + 1

ValueError: all input arrays must have the same shape