### PR TITLE
import warnings for line 129 of labeling/tasks/base.py

### DIFF
--- a/pyannote/audio/labeling/tasks/base.py
+++ b/pyannote/audio/labeling/tasks/base.py
@@ -26,6 +26,7 @@
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
 
+import warnings
 import torch
 import numpy as np
 from tqdm import tqdm


### PR DESCRIPTION
Missing import

flake8 testing of https://github.com/pyannote/pyannote-audio on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pyannote/audio/signal.py:97:30: F821 undefined name 'data'
            mini = np.nanmin(data)
                             ^
./pyannote/audio/signal.py:98:30: F821 undefined name 'data'
            maxi = np.nanmax(data)
                             ^
./pyannote/audio/signal.py:101:37: F821 undefined name 'data'
            mini = np.nanpercentile(data, 1)
                                    ^
./pyannote/audio/signal.py:102:37: F821 undefined name 'data'
            maxi = np.nanpercentile(data, 99)
                                    ^
./pyannote/audio/embedding/clustering.py:283:14: F821 undefined name 'l2_normalize'
        fC = l2_normalize(
             ^
./pyannote/audio/labeling/tasks/base.py:128:17: F821 undefined name 'warnings'
                warnings.warn(msg)
                ^
./pyannote/audio/pipeline/base.py:177:45: F821 undefined name 'sampler'
                                    sampler=sampler)
                                            ^
7     F821 undefined name 'l2_normalize'
7
```