### PR TITLE
Fixed a typo in SCD tutorial

### DIFF
--- a/tutorials/models/speaker_change_detection/README.md
+++ b/tutorials/models/speaker_change_detection/README.md
@@ -80,7 +80,7 @@ Have a look at `pyannote.database` [documentation](http://github.com/pyannote/py
 To ensure reproducibility, `pyannote-change-detection` relies on a configuration file defining the experimental setup:
 
 ```bash
-$ cat tutorials/models/speakker_change_detection/config.yml
+$ cat tutorials/models/speaker_change_detection/config.yml
 ```
 ```yaml
 task:


### PR DESCRIPTION
There was a small typo in the SCD tutorial README. 