### PR TITLE
Specified YAML Loader to BaseLoader.

### DIFF
--- a/pyannote/audio/applications/base.py
+++ b/pyannote/audio/applications/base.py
@@ -95,7 +95,7 @@ class Application(object):
         # load configuration
         config_yml = self.CONFIG_YML.format(experiment_dir=self.experiment_dir)
         with open(config_yml, 'r') as fp:
-            self.config_ = yaml.load(fp)
+            self.config_ = yaml.load(fp, Loader=yaml.BaseLoader)
 
         # preprocessors
         preprocessors = {}
@@ -231,7 +231,7 @@ class Application(object):
         # initialize model from specs stored on disk
         specs_yml = self.task_.SPECS_YML.format(log_dir=train_dir)
         with io.open(specs_yml, 'r') as fp:
-            specifications = yaml.load(fp)
+            specifications = yaml.load(fp, Loader=yaml.BaseLoader)
         self.model_ = self.get_model_(specifications)
 
         import torch

--- a/pyannote/audio/applications/feature_extraction.py
+++ b/pyannote/audio/applications/feature_extraction.py
@@ -89,7 +89,7 @@ def init_feature_extraction(experiment_dir):
     # load configuration file
     config_yml = experiment_dir + '/config.yml'
     with open(config_yml, 'r') as fp:
-        config = yaml.load(fp)
+        config = yaml.load(fp, Loader=yaml.BaseLoader)
 
     FeatureExtraction = get_class_by_name(
         config['feature_extraction']['name'],
@@ -155,7 +155,7 @@ def extract(protocol_name, file_finder, experiment_dir,
     # load configuration file
     config_yml = experiment_dir + '/config.yml'
     with open(config_yml, 'r') as fp:
-        config = yaml.load(fp)
+        config = yaml.load(fp, Loader=yaml.BaseLoader)
 
     FeatureExtraction = get_class_by_name(
         config['feature_extraction']['name'],

--- a/pyannote/audio/features/precomputed.py
+++ b/pyannote/audio/features/precomputed.py
@@ -91,7 +91,7 @@ class Precomputed(object):
         if path.exists():
 
             with io.open(path, 'r') as f:
-                params = yaml.load(f)
+                params = yaml.load(f, Loader=yaml.BaseLoader)
 
             self.dimension_ = params.pop('dimension')
             self.labels_ = params.pop('labels', None)


### PR DESCRIPTION
Due to security issues with the `yaml.load` function, a `Loader` must be specified.
I chose `yaml.BaseLoader` which only parses basic python objects such as dictionnaries, lists and strings. `config.yml` files in pyannote does not need more but it could be replaced easily by another Loader if needed.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more details.