### PR TITLE
Fixed njobs for Domain Classification

### DIFF
--- a/pyannote/audio/applications/domain_classification.py
+++ b/pyannote/audio/applications/domain_classification.py
@@ -317,6 +317,9 @@ def main():
         # batch size
         batch_size = int(arguments['--batch'])
 
+        # number of processes 
+        n_jobs = 1
+
         application = DomainClassification.from_train_dir(
             train_dir, db_yml=db_yml, training=False)
         application.device = device

--- a/pyannote/audio/applications/domain_classification.py
+++ b/pyannote/audio/applications/domain_classification.py
@@ -324,6 +324,7 @@ def main():
             train_dir, db_yml=db_yml, training=False)
         application.device = device
         application.batch_size = batch_size
+        application.n_jobs = n_jobs
         application.validate(protocol_name, subset=subset,
                              start=start, end=end, every=every,
                              in_order=in_order)


### PR DESCRIPTION
**This PR is not ready to be merged**

After this [commit](https://github.com/pyannote/pyannote-audio/commit/fe6d16e3b81cb93d2f253fa813731345b8e68d23), `domain_classification.py` was triggering this error when launched with `validate` flag: 

```
Traceback (most recent call last):
  File "/home/mpgill/anaconda3/envs/pyannote/bin/pyannote-domain-classification", line 11, in <module>
    load_entry_point('pyannote.audio', 'console_scripts', 'pyannote-domain-classification')()
  File "/export/b19/mpgill/pyannote-audio/pyannote/audio/applications/domain_classification.py", line 326, in main
    in_order=in_order)
  File "/export/b19/mpgill/pyannote-audio/pyannote/audio/applications/base.py", line 298, in validate
    **kwargs)
  File "/export/b19/mpgill/pyannote-audio/pyannote/audio/applications/base_labeling.py", line 79, in validate_init
    self.pool_ = mp.Pool(self.n_jobs)
AttributeError: 'DomainClassification' object has no attribute 'n_jobs'
```

This commit aims at fixing this error. 

I tested these changes with `pip install git+https://github.com/Mymoza/pyannote-audio.git@domain-classification-njobs`