### PR TITLE
BREAKING: update behavior of labeling "apply" mode 

### DIFF
--- a/pyannote/audio/applications/base.py
+++ b/pyannote/audio/applications/base.py
@@ -54,6 +54,7 @@ class Application(object):
     WEIGHTS_DIR = '{train_dir}/weights'
     WEIGHTS_PT = '{train_dir}/weights/{epoch:04d}.pt'
     VALIDATE_DIR = '{train_dir}/validate{_task}/{protocol}.{subset}'
+    APPLY_DIR = '{validate_dir}/apply/{epoch:04d}'
 
     @classmethod
     def from_train_dir(cls, train_dir, db_yml=None, training=False):
@@ -63,19 +64,39 @@ class Application(object):
         return app
 
     @classmethod
-    def from_validate_txt(cls, validate_txt, db_yml=None, training=False):
-        train_dir = dirname(dirname(dirname(validate_txt)))
-        app = cls.from_train_dir(train_dir, db_yml=db_yml, training=training)
-        app.validate_txt_ = validate_txt
-        return app
-
-    @classmethod
     def from_model_pt(cls, model_pt, db_yml=None, training=False):
         train_dir = dirname(dirname(model_pt))
         app = cls.from_train_dir(train_dir, db_yml=db_yml, training=training)
         app.model_pt_ = model_pt
         epoch = int(basename(app.model_pt_)[:-3])
         app.model_ = app.load_model(epoch, train_dir=train_dir)
+        app.epoch_ = epoch
+        return app
+
+    @classmethod
+    def from_validate_dir(cls, validate_dir, db_yml=None, training=False):
+
+        # infer train directory from validate directory
+        train_dir = dirname(dirname(validate_dir))
+
+        # load params.yml file from validate directory
+        with open(validate_dir + '/params.yml', 'r') as fp:
+            params_yml = yaml.load(fp)
+
+        # build path to best epoch model
+        epoch = params_yml['epoch']
+        model_pt = self.WEIGHTS_PT.format(train_dir=train_dir,
+                                          epoch=epoch)
+
+        # instantiate application
+        # TODO. get rid of from_model_pt
+        app = cls.from_model_pt(model_t, db_yml=db_yml, training=training)
+        app.validate_dir_ = validate_dir
+        app.epoch_ = epoch
+
+        # keep track of pipeline parameters
+        app.pipeline_params_ = params_yml['params']
+
         return app
 
     def __init__(self, experiment_dir, db_yml=None, training=False):

--- a/pyannote/audio/applications/base.py
+++ b/pyannote/audio/applications/base.py
@@ -88,8 +88,8 @@ class Application(object):
 
         # build path to best epoch model
         epoch = params_yml['epoch']
-        model_pt = self.WEIGHTS_PT.format(train_dir=train_dir,
-                                          epoch=epoch)
+        model_pt = cls.WEIGHTS_PT.format(train_dir=train_dir,
+                                         epoch=epoch)
 
         # instantiate application
         # TODO. get rid of from_model_pt

--- a/pyannote/audio/applications/base.py
+++ b/pyannote/audio/applications/base.py
@@ -31,6 +31,7 @@ import os
 import sys
 import time
 import yaml
+from typing import Optional
 from pathlib import Path
 from os.path import dirname, basename
 import numpy as np
@@ -74,13 +75,15 @@ class Application(object):
         return app
 
     @classmethod
-    def from_validate_dir(cls, validate_dir, db_yml=None, training=False):
+    def from_validate_dir(cls, validate_dir: Path,
+                               db_yml: Optional[Path] = None,
+                               training: Optional[bool] = False):
 
         # infer train directory from validate directory
         train_dir = dirname(dirname(validate_dir))
 
         # load params.yml file from validate directory
-        with open(validate_dir + '/params.yml', 'r') as fp:
+        with open(validate_dir / 'params.yml', 'r') as fp:
             params_yml = yaml.load(fp)
 
         # build path to best epoch model
@@ -95,7 +98,7 @@ class Application(object):
         app.epoch_ = epoch
 
         # keep track of pipeline parameters
-        app.pipeline_params_ = params_yml['params']
+        app.pipeline_params_ = params_yml.get('params', {})
 
         return app
 

--- a/pyannote/audio/applications/base.py
+++ b/pyannote/audio/applications/base.py
@@ -93,7 +93,7 @@ class Application(object):
 
         # instantiate application
         # TODO. get rid of from_model_pt
-        app = cls.from_model_pt(model_t, db_yml=db_yml, training=training)
+        app = cls.from_model_pt(model_pt, db_yml=db_yml, training=training)
         app.validate_dir_ = validate_dir
         app.epoch_ = epoch
 

--- a/pyannote/audio/applications/base_labeling.py
+++ b/pyannote/audio/applications/base_labeling.py
@@ -155,14 +155,22 @@ class BaseLabeling(Application):
                 hypothesis = pipeline(current_file)
                 pipeline.write_rttm(fp, hypothesis)
 
+                # compute evaluation metric (when possible)
+                if 'annotation' not in current_file:
+                    metric = None
+
                 # compute evaluation metric (when available)
                 if metric is None:
                     continue
+
                 reference = current_file['annotation']
                 uem = get_annotated(current_file)
                 _ = metric(reference, hypothesis, uem=uem)
 
         # print pipeline metric (when available)
-        if metric is not None:
-            _ = metric.report(display=True)
-            # TODO. dump metric report to file
+        if metric is None:
+            return
+
+        output_eval = output_dir / f'{protocol_name}.{subset}.eval'
+        with open(output_eval, 'w') as fp:
+            fp.write(str(metric))

--- a/pyannote/audio/applications/base_labeling.py
+++ b/pyannote/audio/applications/base_labeling.py
@@ -93,7 +93,7 @@ class BaseLabeling(Application):
 
     def apply(self, protocol_name: str,
                     step: Optional[float] = None,
-                    subset: Optional[str] = None):
+                    subset: Optional[str] = "test"):
 
         model = self.model_.to(self.device)
         model.eval()
@@ -129,19 +129,9 @@ class BaseLabeling(Application):
         protocol = get_protocol(protocol_name, progress=True,
                                 preprocessors=self.preprocessors_)
 
-        if subset is None:
-            files = FileFinder.protocol_file_iter(protocol,
-                                                  extra_keys=['audio'])
-        else:
-            files = getattr(protocol, subset)()
-
-        for current_file in files:
+        for current_file in getattr(protocol, subset)():
             fX = sequence_labeling(current_file)
             precomputed.dump(current_file, fX)
-
-        # do not proceed with the full pipeline when subset is not provided
-        if subset is None:
-            return
 
         # do not proceed with the full pipeline
         # when there is no such thing for current task
@@ -161,7 +151,7 @@ class BaseLabeling(Application):
         # apply pipeline and dump output to RTTM files
         output_rttm = output_dir / f'{protocol_name}.{subset}.rttm'
         with open(output_rttm, 'w') as fp:
-            for current_file in files:
+            for current_file in getattr(protocol, subset)():
                 hypothesis = pipeline(current_file)
                 pipeline.write_rttm(fp, hypothesis)
 

--- a/pyannote/audio/applications/base_labeling.py
+++ b/pyannote/audio/applications/base_labeling.py
@@ -26,11 +26,13 @@
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
 
-
+from typing import Optional
+from pathlib import Path
 from tqdm import tqdm
 from .base import Application
 from pyannote.database import FileFinder
 from pyannote.database import get_protocol
+from pyannote.database import get_annotated
 from pyannote.audio.features import Precomputed
 from pyannote.audio.features import RawAudio
 from pyannote.audio.labeling.extraction import SequenceLabeling
@@ -89,7 +91,9 @@ class BaseLabeling(Application):
 
         return validation_data
 
-    def apply(self, protocol_name, output_dir, step=None, subset=None):
+    def apply(self, protocol_name: str,
+                    step: Optional[float] = None,
+                    subset: Optional[str] = None):
 
         model = self.model_.to(self.device)
         model.eval()
@@ -97,6 +101,10 @@ class BaseLabeling(Application):
         duration = self.task_.duration
         if step is None:
             step = 0.25 * duration
+
+        output_dir = Path(self.APPLY_DIR.format(
+            validate_dir=self.validate_dir_,
+            epoch=self.epoch_))
 
         # do not use memmap as this would lead to too many open files
         if isinstance(self.feature_extraction_, Precomputed):
@@ -130,3 +138,41 @@ class BaseLabeling(Application):
         for current_file in files:
             fX = sequence_labeling(current_file)
             precomputed.dump(current_file, fX)
+
+        # do not proceed with the full pipeline when subset is not provided
+        if subset is None:
+            return
+
+        # do not proceed with the full pipeline
+        # when there is no such thing for current task
+        if not hasattr(self, 'pipeline_params_'):
+            return
+
+        # instantiate pipeline
+        pipeline = self.Pipeline(scores=output_dir)
+        pipeline.instantiate(self.pipeline_params_)
+
+        # load pipeline metric (when available)
+        try:
+            metric = pipeline.get_metric()
+        except NotImplementedError as e:
+            metric = None
+
+        # apply pipeline and dump output to RTTM files
+        output_rttm = output_dir / f'{protocol_name}.{subset}.rttm'
+        with open(output_rttm, 'w') as fp:
+            for current_file in files:
+                hypothesis = pipeline(current_file)
+                pipeline.write_rttm(fp, hypothesis)
+
+                # compute evaluation metric (when available)
+                if metric is None:
+                    continue
+                reference = current_file['annotation']
+                uem = get_annotated(current_file)
+                _ = metric(reference, hypothesis, uem=uem)
+
+        # print pipeline metric (when available)
+        if metric is not None:
+            _ = metric.report(display=True)
+            # TODO. dump metric report to file

--- a/pyannote/audio/applications/change_detection.py
+++ b/pyannote/audio/applications/change_detection.py
@@ -210,7 +210,7 @@ class SpeakerChangeDetection(BaseLabeling):
 
             current_alpha = .5 * (lower_alpha + upper_alpha)
             pipeline.instantiate({'alpha': current_alpha,
-                                  'min_duration': 0.})
+                                  'min_duration': 0.100})
 
             if self.diarization:
                 metric = DiarizationPurityCoverageFMeasure(parallel=True)
@@ -239,7 +239,7 @@ class SpeakerChangeDetection(BaseLabeling):
                 'value': best_coverage if best_coverage \
                          else purity - self.purity,
                 'pipeline': pipeline.instantiate({'alpha': best_alpha,
-                                                  'min_duration': 0.})}
+                                                  'min_duration': 0.100})}
 
 
 def main():

--- a/pyannote/audio/applications/change_detection.py
+++ b/pyannote/audio/applications/change_detection.py
@@ -33,7 +33,7 @@ Speaker change detection
 Usage:
   pyannote-change-detection train [options] <experiment_dir> <database.task.protocol>
   pyannote-change-detection validate [options] [--every=<epoch> --chronological --purity=<purity>] <train_dir> <database.task.protocol>
-  pyannote-change-detection apply [options] [--step=<step>] <model.pt> <database.task.protocol> <output_dir>
+  pyannote-change-detection apply [options] [--step=<step>] <validate_dir> <database.task.protocol>
   pyannote-change-detection -h | --help
   pyannote-change-detection --version
 
@@ -42,8 +42,8 @@ Common options:
   --database=<database.yml>  Path to pyannote.database configuration file.
   --subset=<subset>          Set subset (train|developement|test).
                              Defaults to "train" in "train" mode. Defaults to
-                             "development" in "validate" mode. Defaults to all subsets in
-                             "apply" mode.
+                             "development" in "validate" mode. Defaults to
+                             "test" in "apply" mode.
   --gpu                      Run on GPUs. Defaults to using CPUs.
   --batch=<size>             Set batch size. Has no effect in "train" mode.
                              [default: 32]
@@ -69,7 +69,8 @@ Common options:
   --diarization              Use diarization instead of segmentation metrics.
 
 "apply" mode:
-  <model.pt>                 Path to the pretrained model.
+  <validate_dir>             Path to the directory containing validation
+                             results (i.e. the output of "validate" mode).
   --step=<step>              Sliding window step, in seconds.
                              Defaults to 25% of window duration.
 
@@ -144,21 +145,11 @@ Configuration file:
     "--purity" option.
 
 "apply" mode:
-    Use the "apply" mode to extract speaker change detection raw scores.
-    Resulting files can then be used in the following way:
+    Use the "apply" mode to extract speaker change detection raw scores and
+    results. This will create the following directory that contains speaker
+    change detection results:
 
-    >>> from pyannote.audio.features import Precomputed
-    >>> precomputed = Precomputed('<output_dir>')
-
-    >>> from pyannote.database import get_protocol
-    >>> protocol = get_protocol('<database.task.protocol>')
-    >>> first_test_file = next(protocol.test())
-
-    >>> from pyannote.audio.signal import Peak
-    >>> peak_detection = Peak()
-
-    >>> raw_scores = precomputed(first_test_file)
-    >>> homogeneous_segments = peak_detection.apply(raw_scores, dimension=1)
+        <validate_dir>/apply/<epoch>
 """
 
 from functools import partial
@@ -186,6 +177,8 @@ def validate_helper_func(current_file, pipeline=None, metric=None):
 
 class SpeakerChangeDetection(BaseLabeling):
 
+    Pipeline = SpeakerChangeDetectionPipeline
+
     def validate_epoch(self, epoch, protocol_name, subset='development',
                        validation_data=None):
 
@@ -203,7 +196,7 @@ class SpeakerChangeDetection(BaseLabeling):
             current_file['scd_scores'] = sequence_labeling(current_file)
 
         # pipeline
-        pipeline = SpeakerChangeDetectionPipeline(purity=self.purity)
+        pipeline = self.Pipeline(purity=self.purity)
 
         # dichotomic search to find alpha that maximizes coverage
         # while having at least `self.purity`
@@ -258,6 +251,9 @@ def main():
 
     gpu = arguments['--gpu']
     device = torch.device('cuda') if gpu else torch.device('cpu')
+
+    # HACK to "book" GPU as soon as possible
+    _ = torch.Tensor([0]).to(device)
 
     if arguments['train']:
         experiment_dir = Path(arguments['<experiment_dir>'])
@@ -333,13 +329,11 @@ def main():
 
     if arguments['apply']:
 
-        model_pt = Path(arguments['<model.pt>'])
-        model_pt = model_pt.expanduser().resolve(strict=True)
+        validate_dir = Path(arguments['<validate_dir>'])
+        validate_dir = validate_dir.expanduser().resolve(strict=True)
 
-        output_dir = Path(arguments['<output_dir>'])
-        output_dir = output_dir.expanduser().resolve(strict=False)
-
-        # TODO. create README file in <output_dir>
+        if subset is None:
+            subset = 'test'
 
         step = arguments['--step']
         if step is not None:
@@ -347,8 +341,8 @@ def main():
 
         batch_size = int(arguments['--batch'])
 
-        application = SpeakerChangeDetection.from_model_pt(
-            model_pt, db_yml=db_yml, training=False)
+        application = SpeakerChangeDetection.from_validate_dir(
+            validate_dir, db_yml=db_yml, training=False)
         application.device = device
         application.batch_size = batch_size
-        application.apply(protocol_name, output_dir, step=step, subset=subset)
+        application.apply(protocol_name, step=step, subset=subset)

--- a/pyannote/audio/applications/overlap_detection.py
+++ b/pyannote/audio/applications/overlap_detection.py
@@ -229,8 +229,8 @@ class OverlapDetection(BaseLabeling):
             current_alpha = .5 * (lower_alpha + upper_alpha)
             pipeline.instantiate({'onset': current_alpha,
                                   'offset': current_alpha,
-                                  'min_duration_on': 0.,
-                                  'min_duration_off': 0.,
+                                  'min_duration_on': 0.100,
+                                  'min_duration_off': 0.100,
                                   'pad_onset': 0.,
                                   'pad_offset': 0.})
 
@@ -270,8 +270,8 @@ class OverlapDetection(BaseLabeling):
                          else precision - self.precision,
                 'pipeline': pipeline.instantiate({'onset': best_alpha,
                                                   'offset': best_alpha,
-                                                  'min_duration_on': 0.,
-                                                  'min_duration_off': 0.,
+                                                  'min_duration_on': 0.100,
+                                                  'min_duration_off': 0.100,
                                                   'pad_onset': 0.,
                                                   'pad_offset': 0.})}
 

--- a/pyannote/audio/applications/overlap_detection.py
+++ b/pyannote/audio/applications/overlap_detection.py
@@ -32,7 +32,7 @@ Overlapping speech detection
 Usage:
   pyannote-overlap-detection train [options] <experiment_dir> <database.task.protocol>
   pyannote-overlap-detection validate [options] [--every=<epoch> --chronological --precision=<precision>] <train_dir> <database.task.protocol>
-  pyannote-overlap-detection apply [options] [--step=<step>] <model.pt> <database.task.protocol> <output_dir>
+  pyannote-overlap-detection apply [options] [--step=<step>] <validate_dir> <database.task.protocol>
   pyannote-overlap-detection -h | --help
   pyannote-overlap-detection --version
 
@@ -41,8 +41,8 @@ Common options:
   --database=<database.yml>  Path to pyannote.database configuration file.
   --subset=<subset>          Set subset (train|developement|test).
                              Defaults to "train" in "train" mode. Defaults to
-                             "development" in "validate" mode. Defaults to all subsets in
-                             "apply" mode.
+                             "development" in "validate" mode. Defaults to
+                             "test" in "apply" mode.
   --gpu                      Run on GPUs. Defaults to using CPUs.
   --batch=<size>             Set batch size. Has no effect in "train" mode.
                              [default: 32]
@@ -67,7 +67,8 @@ Common options:
   --precision=<precision>    Target detection precision [default: 0.8].
 
 "apply" mode:
-  <model.pt>                 Path to the pretrained model.
+  <validate_dir>             Path to the directory containing validation
+                             results (i.e. the output of "validate" mode).
   --step=<step>              Sliding window step, in seconds.
                              Defaults to 25% of window duration.
 
@@ -141,23 +142,12 @@ Configuration file:
     "--precision" option.
 
 "apply" mode:
-    Use the "apply" mode to extract overlapping speech detection raw scores.
-    Resulting files can then be used in the following way:
+    Use the "apply" mode to extract overlapped speech detection raw scores and
+    results. This will create the following directory that contains overlapped
+    speech detection results:
 
-    >>> from pyannote.audio.features import Precomputed
-    >>> precomputed = Precomputed('<output_dir>')
-
-    >>> from pyannote.database import get_protocol
-    >>> protocol = get_protocol('<database.task.protocol>')
-    >>> first_test_file = next(protocol.test())
-
-    >>> from pyannote.audio.signal import Binarize
-    >>> binarizer = Binarize()
-
-    >>> raw_scores = precomputed(first_test_file)
-    >>> overlap_regions = binarizer.apply(raw_scores, dimension=1)
+        <validate_dir>/apply/<epoch>
 """
-
 
 from functools import partial
 from pathlib import Path
@@ -187,6 +177,8 @@ def validate_helper_func(current_file, pipeline=None,
 
 
 class OverlapDetection(BaseLabeling):
+
+    Pipeline = OverlapDetectionPipeline
 
     def validate_init(self, protocol_name, subset='development'):
         validation_data = super().validate_init(protocol_name, subset=subset)
@@ -222,7 +214,7 @@ class OverlapDetection(BaseLabeling):
             current_file['ovl_scores'] = sequence_labeling(current_file)
 
         # pipeline
-        pipeline = OverlapDetectionPipeline(precision=self.precision)
+        pipeline = self.Pipeline(precision=self.precision)
 
         # dichotomic search to find threshold that maximizes recall
         # while having at least `target_precision`
@@ -293,7 +285,7 @@ def main():
     gpu = arguments['--gpu']
     device = torch.device('cuda') if gpu else torch.device('cpu')
 
-    # HACK for JHU/CLSP cluster
+    # HACK to "book" GPU as soon as possible
     _ = torch.Tensor([0]).to(device)
 
     if arguments['train']:
@@ -369,13 +361,11 @@ def main():
 
     if arguments['apply']:
 
-        model_pt = Path(arguments['<model.pt>'])
-        model_pt = model_pt.expanduser().resolve(strict=True)
+        validate_dir = Path(arguments['<validate_dir>'])
+        validate_dir = validate_dir.expanduser().resolve(strict=True)
 
-        output_dir = Path(arguments['<output_dir>'])
-        output_dir = output_dir.expanduser().resolve(strict=False)
-
-        # TODO. create README file in <output_dir>
+        if subset is None:
+            subset = 'test'
 
         step = arguments['--step']
         if step is not None:
@@ -383,8 +373,8 @@ def main():
 
         batch_size = int(arguments['--batch'])
 
-        application = OverlapDetection.from_model_pt(
-            model_pt, db_yml=db_yml, training=False)
+        application = OverlapDetection.from_validate_dir(
+            validate_dir, db_yml=db_yml, training=False)
         application.device = device
         application.batch_size = batch_size
-        application.apply(protocol_name, output_dir, step=step, subset=subset)
+        application.apply(protocol_name, step=step, subset=subset)

--- a/pyannote/audio/applications/speech_detection.py
+++ b/pyannote/audio/applications/speech_detection.py
@@ -41,8 +41,8 @@ Common options:
   --database=<database.yml>  Path to pyannote.database configuration file.
   --subset=<subset>          Set subset (train|developement|test).
                              Defaults to "train" in "train" mode. Defaults to
-                             "development" in "validate" mode. Defaults to all subsets in
-                             "apply" mode.
+                             "development" in "validate" mode. Defaults to
+                             "test" in "apply" mode.
   --gpu                      Run on GPUs. Defaults to using CPUs.
   --batch=<size>             Set batch size. Has no effect in "train" mode.
                              [default: 32]
@@ -305,6 +305,9 @@ def main():
         validate_dir = Path(arguments['<validate_dir>'])
         validate_dir = validate_dir.expanduser().resolve(strict=True)
 
+        if subset is None:
+            subset = 'test'
+        
         step = arguments['--step']
         if step is not None:
             step = float(step)

--- a/pyannote/audio/applications/speech_detection.py
+++ b/pyannote/audio/applications/speech_detection.py
@@ -231,7 +231,7 @@ def main():
     gpu = arguments['--gpu']
     device = torch.device('cuda') if gpu else torch.device('cpu')
 
-    # HACK for JHU/CLSP cluster
+    # HACK to "book" GPU as soon as possible
     _ = torch.Tensor([0]).to(device)
 
     if arguments['train']:
@@ -307,7 +307,7 @@ def main():
 
         if subset is None:
             subset = 'test'
-        
+
         step = arguments['--step']
         if step is not None:
             step = float(step)

--- a/pyannote/audio/applications/speech_detection.py
+++ b/pyannote/audio/applications/speech_detection.py
@@ -193,8 +193,8 @@ class SpeechActivityDetection(BaseLabeling):
         def fun(threshold):
             pipeline.instantiate({'onset': threshold,
                                   'offset': threshold,
-                                  'min_duration_on': 0.,
-                                  'min_duration_off': 0.,
+                                  'min_duration_on': 0.100,
+                                  'min_duration_off': 0.100,
                                   'pad_onset': 0.,
                                   'pad_offset': 0.})
             metric = pipeline.get_metric(parallel=True)
@@ -215,8 +215,8 @@ class SpeechActivityDetection(BaseLabeling):
                 'value': res.fun,
                 'pipeline': pipeline.instantiate({'onset': threshold,
                                                   'offset': threshold,
-                                                  'min_duration_on': 0.,
-                                                  'min_duration_off': 0.,
+                                                  'min_duration_on': 0.100,
+                                                  'min_duration_off': 0.100,
                                                   'pad_onset': 0.,
                                                   'pad_offset': 0.})}
 

--- a/pyannote/audio/applications/speech_detection.py
+++ b/pyannote/audio/applications/speech_detection.py
@@ -32,7 +32,7 @@ Speech activity detection
 Usage:
   pyannote-speech-detection train [options] <experiment_dir> <database.task.protocol>
   pyannote-speech-detection validate [options] [--every=<epoch> --chronological] <train_dir> <database.task.protocol>
-  pyannote-speech-detection apply [options] [--step=<step>] <validate_dir> <database.task.protocol> <output_dir>
+  pyannote-speech-detection apply [options] [--step=<step>] <validate_dir> <database.task.protocol>
   pyannote-speech-detection -h | --help
   pyannote-speech-detection --version
 
@@ -138,21 +138,11 @@ Configuration file:
     threshold that minimizes the detection error rate.
 
 "apply" mode:
-    Use the "apply" mode to extract speech activity detection raw scores.
-    Resulting files can then be used in the following way:
+    Use the "apply" mode to extract speech activity detection raw scores and
+    results. This will create the following directory that contains speech
+    activity detection results:
 
-    >>> from pyannote.audio.features import Precomputed
-    >>> precomputed = Precomputed('<output_dir>')
-
-    >>> from pyannote.database import get_protocol
-    >>> protocol = get_protocol('<database.task.protocol>')
-    >>> first_test_file = next(protocol.test())
-
-    >>> from pyannote.audio.signal import Binarize
-    >>> binarizer = Binarize()
-
-    >>> raw_scores = precomputed(first_test_file)
-    >>> speech_regions = binarizer.apply(raw_scores, dimension=1)
+        <validate_dir>/apply/<epoch>
 """
 
 from functools import partial

--- a/pyannote/audio/pipeline/overlap_detection.py
+++ b/pyannote/audio/pipeline/overlap_detection.py
@@ -50,7 +50,7 @@ class OverlapDetection(Pipeline):
     scores : `Path`, optional
         Path to precomputed scores on disk.
     precision : `float`, optional
-        Target detection precision. Defaults to 0.8.
+        Target detection precision. Defaults to 0.9.
 
     Hyper-parameters
     ----------------
@@ -63,7 +63,7 @@ class OverlapDetection(Pipeline):
     """
 
     def __init__(self, scores: Optional[Path] = None,
-                       precision: Optional[Path] = 0.8):
+                       precision: Optional[Path] = 0.9):
         super().__init__()
 
         self.scores = scores

--- a/pyannote/audio/pipeline/speech_activity_detection.py
+++ b/pyannote/audio/pipeline/speech_activity_detection.py
@@ -140,6 +140,8 @@ class SpeechActivityDetection(Pipeline):
         speech.uri = current_file['uri']
         return speech.to_annotation(generator='string', modality='speech')
 
-    def get_metric(self) -> DetectionErrorRate:
+    def get_metric(self, parallel=False) -> DetectionErrorRate:
         """Return new instance of detection error rate metric"""
-        return  DetectionErrorRate(collar=0.0, skip_overlap=False)
+        return  DetectionErrorRate(collar=0.0,
+                                   skip_overlap=False,
+                                   parallel=parallel)

--- a/pyannote/audio/pipeline/speech_activity_detection.py
+++ b/pyannote/audio/pipeline/speech_activity_detection.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2018 CNRS
+# Copyright (c) 2018-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -70,6 +70,15 @@ class SpeechActivityDetection(Pipeline):
     ----------
     scores : `Path`, optional
         Path to precomputed scores on disk.
+
+    Hyper-parameters
+    ----------------
+    onset, offset : `float`
+        Onset/offset detection thresholds
+    min_duration_on, min_duration_off : `float`
+        Minimum duration in either state (speech or not)
+    pad_onset, pad_offset : `float`
+        Padding duration.
     """
 
     def __init__(self, scores: Optional[Path] = None):


### PR DESCRIPTION
- "apply" mode now expects a path to the validation directory as input, and read everything from the `params.yml` file directly.
- "apply" mode now creates its output as a sub-directory of the validation directory.
- "apply" mode now creates RTTM files directly (and evaluate the performance, when applicable)