### PR TITLE
improve: refactor DomainAdversarial and DomainAware

### DIFF
--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -371,7 +371,7 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        loss, domain_target = super()._batch_loss(self, batch)
+        loss, domain_target = super()._batch_loss(batch)
 
         domain_scores = self.activation_(self.domain_classifier_(
             self.gradient_reversal_(intermediate)))

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -358,7 +358,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSp
 
         #domain_scores = self.activation_(self.domain_classifier_(intermediate)) 
 
-        return super(DomainBranchSpeechActivityDetection)._batch_loss(batch)
+        return super(DomainBranchSpeechActivityDetection, self)._batch_loss(batch)
         #return self._batch_loss(batch)
 
         
@@ -404,7 +404,7 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        return super()._batch_loss(batch)
+        return super(DomainBranchSpeechActivityDetection, self)._batch_loss(batch)
 
         
 

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -124,7 +124,15 @@ class SpeechActivityDetection(LabelingTask):
 
     def get_batch_generator(self, feature_extraction, protocol, subset='train',
                             frame_info=None, frame_crop=None):
-        """
+        """Returns a batch generator for training speech activity detection
+
+         Parameters
+        ----------
+        feature_extraction : `pyannote.audio.features.FeatureExtraction`
+            Feature extraction
+        protocol : `pyannote.database.Protocol`
+        subset : {'train', 'development', 'test'}
+            Dataset subset to use. Defaults to 'train'.
         frame_info : `pyannote.core.SlidingWindow`, optional
             Override `feature_extraction.sliding_window`. This is useful for
             models that include the feature extraction step (e.g. SincNet) and
@@ -200,8 +208,12 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
 
         Parameters
         ----------
+        model : `nn.Module`
+            Model.
         specifications : `dict`
             Batch specs.
+        device : `torch.device`
+            Device
 
         Returns
         -------

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -202,7 +202,6 @@ class DomainBranchSpeechActivityDetection(ABC):
             nb_domains = domain_scores.shape[1]
             identity_mat = torch.sparse.torch.eye(nb_domains, device=self.device_)
             domain_target = identity_mat.index_select(dim=0, index=domain_target)
-
         
         domain_loss = self.domain_loss_(domain_scores, domain_target)
 
@@ -389,8 +388,6 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
         """
 
         return super()._batch_loss(batch)
-
-        
 
     def get_domain_scores(self, intermediate):
         return self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -175,7 +175,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
     DOMAIN_PT = '{log_dir}/weights/{epoch:04d}.domain.pt'
 
     def __init__(self, 
-                 domain='domain', attachment=-1, 
+                 domain='domain', attachment=-1, alpha=1.,
                  rnn=None, domain_loss="NLLLoss", 
                  **kwargs):
         super().__init__(**kwargs)

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -393,6 +393,5 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
         
 
     def get_domain_scores(self, intermediate):
-        print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT ADVERSARIAL!!!!!!!!!!!!")
         return self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
 

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -358,7 +358,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSp
 
         #domain_scores = self.activation_(self.domain_classifier_(intermediate)) 
 
-        return super(DomainBranchSpeechActivityDetection, self)._batch_loss(batch)
+        return super()._batch_loss(batch)
         #return self._batch_loss(batch)
 
         
@@ -404,7 +404,7 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        return super(DomainBranchSpeechActivityDetection, self)._batch_loss(batch)
+        return super()._batch_loss(batch)
 
         
 

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -308,7 +308,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
             dtype=torch.int64,
             device=self.device_)
 
-        return loss, domain_target
+        return loss, domain_target, intermediate
 
     def batch_loss(self, batch):
         """Compute loss for current `batch`
@@ -325,7 +325,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        loss, domain_target = self._batch_loss(self, batch)
+        loss, domain_target, intermediate = self._batch_loss(self, batch)
 
         domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
@@ -371,7 +371,7 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        loss, domain_target = super()._batch_loss(batch)
+        loss, domain_target, intermediate = super()._batch_loss(batch)
 
         domain_scores = self.activation_(self.domain_classifier_(
             self.gradient_reversal_(intermediate)))

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -269,6 +269,19 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
         super().save_epoch(epoch=epoch)
     
     def _batch_loss(self, batch):
+        """Helper function to performs the common operations required for the batch_loss function 
+
+        Parameters
+        ----------
+        batch : `dict`
+            ['X'] (`numpy.ndarray`)
+            ['y'] (`numpy.ndarray`)
+
+        Returns
+        -------
+        loss : Function f(input, target, weight=None) -> loss value
+        domain_target : `torch.Tensor`
+        """
         X = torch.tensor(batch['X'],
                          dtype=torch.float32,
                          device=self.device_)

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -184,6 +184,8 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
 
         if rnn is None:
             rnn = dict()
+            rnn.update({'pool' : 'max'})
+            print("You might want to declare a RNN in your config file and provide a way to do pooling. Max pooling have been used by default at this time.")
         self.rnn = rnn
 
         self.domain_loss = domain_loss

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -325,7 +325,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        loss, domain_target, intermediate = self._batch_loss(self, batch)
+        loss, domain_target, intermediate = self._batch_loss(batch)
 
         domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
@@ -375,7 +375,7 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
 
         domain_scores = self.activation_(self.domain_classifier_(
             self.gradient_reversal_(intermediate)))
-        
+
         if self.domain_loss == "MSELoss":
             # One hot encode domain_target for Mean Squared Error Loss
             nb_domains = domain_scores.shape[1]

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -36,6 +36,7 @@ from .base import LabelingTaskGenerator
 from .base import TASK_MULTI_CLASS_CLASSIFICATION
 from ..gradient_reversal import GradientReversal
 from pyannote.audio.models.models import RNN
+from abc import ABC, abstractmethod
 
 class SpeechActivityDetectionGenerator(LabelingTaskGenerator):
     """Batch generator for training speech activity detection
@@ -152,7 +153,70 @@ class SpeechActivityDetection(LabelingTask):
             batch_size=self.batch_size,
             parallel=self.parallel) 
 
-class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
+class DomainBranchSpeechActivityDetection(ABC):
+
+    @abstractmethod
+    def get_domain_scores(self, intermediate):
+        pass
+
+    def _batch_loss(self, batch):
+    """Helper function to performs the common operations required for the batch_loss function 
+
+    Parameters
+    ----------
+    batch : `dict`
+        ['X'] (`numpy.ndarray`)
+        ['y'] (`numpy.ndarray`)
+
+    Returns
+    -------
+    loss : Function f(input, target, weight=None) -> loss value
+    TO DO 
+    """
+    X = torch.tensor(batch['X'],
+                     dtype=torch.float32,
+                     device=self.device_)
+    fX, intermediate = self.model_(X, return_intermediate=self.attachment)
+
+    # speech activity detection
+    fX = fX.view((-1, self.n_classes_))
+    target = torch.tensor(
+        batch['y'],
+        dtype=torch.int64,
+        device=self.device_).contiguous().view((-1, ))
+
+    weight = self.weight
+    if weight is not None:
+        weight = weight.to(device=self.device_)
+    loss = self.loss_func_(fX, target, weight=weight)
+
+    # domain classification
+    domain_target = torch.tensor(
+        batch[self.domain],
+        dtype=torch.int64,
+        device=self.device_)
+
+    domain_scores = self.get_domain_scores(intermediate)
+    
+    # if gradient_reversal:
+    #     domain_scores = self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
+    # else:
+    #     domain_scores = self.activation_(self.domain_classifier_(intermediate))
+
+    if self.domain_loss == "MSELoss":
+        # One hot encode domain_target for Mean Squared Error Loss
+        nb_domains = domain_scores.shape[1]
+        identity_mat = torch.sparse.torch.eye(nb_domains, device=self.device_)
+        domain_target = identity_mat.index_select(dim=0, index=domain_target)
+
+    
+    domain_loss = self.domain_loss_(domain_scores, domain_target)
+
+    return {'loss': loss + self.alpha * domain_loss,
+            'loss_domain': domain_loss,
+            'loss_task': loss}
+
+class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSpeechActivityDetection):
     """Domain-aware speech activity detection
 
     Trains speech activity detection and domain classification jointly.
@@ -271,60 +335,11 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
 
         super().save_epoch(epoch=epoch)
     
-    def _batch_loss(self, batch, gradient_reversal=False):
-        """Helper function to performs the common operations required for the batch_loss function 
 
-        Parameters
-        ----------
-        batch : `dict`
-            ['X'] (`numpy.ndarray`)
-            ['y'] (`numpy.ndarray`)
 
-        Returns
-        -------
-        loss : Function f(input, target, weight=None) -> loss value
-        TO DO 
-        """
-        X = torch.tensor(batch['X'],
-                         dtype=torch.float32,
-                         device=self.device_)
-        fX, intermediate = self.model_(X, return_intermediate=self.attachment)
-
-        # speech activity detection
-        fX = fX.view((-1, self.n_classes_))
-        target = torch.tensor(
-            batch['y'],
-            dtype=torch.int64,
-            device=self.device_).contiguous().view((-1, ))
-
-        weight = self.weight
-        if weight is not None:
-            weight = weight.to(device=self.device_)
-        loss = self.loss_func_(fX, target, weight=weight)
-
-        # domain classification
-        domain_target = torch.tensor(
-            batch[self.domain],
-            dtype=torch.int64,
-            device=self.device_)
-
-        if gradient_reversal:
-            domain_scores = self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
-        else:
-            domain_scores = self.activation_(self.domain_classifier_(intermediate))
-
-        if self.domain_loss == "MSELoss":
-            # One hot encode domain_target for Mean Squared Error Loss
-            nb_domains = domain_scores.shape[1]
-            identity_mat = torch.sparse.torch.eye(nb_domains, device=self.device_)
-            domain_target = identity_mat.index_select(dim=0, index=domain_target)
-
-        
-        domain_loss = self.domain_loss_(domain_scores, domain_target)
-
-        return {'loss': loss + self.alpha * domain_loss,
-                'loss_domain': domain_loss,
-                'loss_task': loss}
+    def get_domain_scores(self, intermediate):
+        print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT AWARE!!!!!!!!!!!!")
+        return domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
     def batch_loss(self, batch):
         """Compute loss for current `batch`
@@ -343,7 +358,8 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
 
         #domain_scores = self.activation_(self.domain_classifier_(intermediate)) 
 
-        return self._batch_loss(batch)
+        return super(DomainBranchSpeechActivityDetection)._batch_loss(batch)
+        #return self._batch_loss(batch)
 
         
 
@@ -388,11 +404,13 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        return super()._batch_loss(batch, gradient_reversal=True)
+        return super()._batch_loss(batch)
 
         
 
-        
+    def get_domain_scores(self, intermediate):
+        print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT ADVERSARIAL!!!!!!!!!!!!")
+        return self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
 
         # return {'loss': loss + self.alpha * domain_loss,
         #         'loss_domain': domain_loss,

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -339,7 +339,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSp
 
     def get_domain_scores(self, intermediate):
         print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT AWARE!!!!!!!!!!!!")
-        return domain_scores = self.activation_(self.domain_classifier_(intermediate))
+        return self.activation_(self.domain_classifier_(intermediate))
 
     def batch_loss(self, batch):
         """Compute loss for current `batch`

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -150,36 +150,7 @@ class SpeechActivityDetection(LabelingTask):
             duration=self.duration,
             per_epoch=self.per_epoch,
             batch_size=self.batch_size,
-            parallel=self.parallel)
-
-    def batch_loss(self, batch):
-        X = torch.tensor(batch['X'],
-                         dtype=torch.float32,
-                         device=self.device_)
-
-        fX, intermediate = self.model_(X, return_intermediate=self.attachment)
-
-        # speech activity detection
-        fX = fX.view((-1, self.n_classes_))
-
-        target = torch.tensor(
-            batch['y'],
-            dtype=torch.int64,
-            device=self.device_).contiguous().view((-1, ))
-
-        weight = self.weight
-        if weight is not None:
-            weight = weight.to(device=self.device_)
-
-        loss = self.loss_func_(fX, target, weight=weight)
-
-        # domain classification
-        domain_target = torch.tensor(
-            batch[self.domain],
-            dtype=torch.int64,
-            device=self.device_)
-
-        return loss, domain_target 
+            parallel=self.parallel) 
 
 class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
     """Domain-aware speech activity detection
@@ -296,6 +267,35 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
                                              epoch=epoch))
 
         super().save_epoch(epoch=epoch)
+    
+    def _batch_loss(self, batch):
+        X = torch.tensor(batch['X'],
+                         dtype=torch.float32,
+                         device=self.device_)
+
+        fX, intermediate = self.model_(X, return_intermediate=self.attachment)
+
+        # speech activity detection
+        fX = fX.view((-1, self.n_classes_))
+
+        target = torch.tensor(
+            batch['y'],
+            dtype=torch.int64,
+            device=self.device_).contiguous().view((-1, ))
+
+        weight = self.weight
+        if weight is not None:
+            weight = weight.to(device=self.device_)
+
+        loss = self.loss_func_(fX, target, weight=weight)
+
+        # domain classification
+        domain_target = torch.tensor(
+            batch[self.domain],
+            dtype=torch.int64,
+            device=self.device_)
+
+        return loss, domain_target
 
     def batch_loss(self, batch):
         """Compute loss for current `batch`
@@ -336,7 +336,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
         #     dtype=torch.int64,
         #     device=self.device_)
 
-        loss, domain_target = super().batch_loss(self, batch)
+        loss, domain_target = self._batch_loss(self, batch)
 
         domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
@@ -411,8 +411,8 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
         # domain_scores = self.activation_(self.domain_classifier_(
         #     self.gradient_reversal_(intermediate)))
 
-        loss, domain_target = super().batch_loss(self, batch)
-        
+        loss, domain_target = super()._batch_loss(self, batch)
+
         if self.domain_loss == "MSELoss":
             # One hot encode domain_target for Mean Squared Error Loss
             nb_domains = domain_scores.shape[1]

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -312,30 +312,6 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        # forward pass
-        # X = torch.tensor(batch['X'],
-        #                  dtype=torch.float32,
-        #                  device=self.device_)
-        # fX, intermediate = self.model_(X, return_intermediate=self.attachment)
-
-        # # speech activity detection
-        # fX = fX.view((-1, self.n_classes_))
-        # target = torch.tensor(
-        #     batch['y'],
-        #     dtype=torch.int64,
-        #     device=self.device_).contiguous().view((-1, ))
-
-        # weight = self.weight
-        # if weight is not None:
-        #     weight = weight.to(device=self.device_)
-        # loss = self.loss_func_(fX, target, weight=weight)
-
-        # # domain classification
-        # domain_target = torch.tensor(
-        #     batch[self.domain],
-        #     dtype=torch.int64,
-        #     device=self.device_)
-
         loss, domain_target = self._batch_loss(self, batch)
 
         domain_scores = self.activation_(self.domain_classifier_(intermediate))
@@ -381,35 +357,6 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
         batch_loss : `dict`
             ['loss'] (`torch.Tensor`) : Loss
         """
-        # forward pass
-        # X = torch.tensor(batch['X'],
-        #                  dtype=torch.float32,
-        #                  device=self.device_)
-
-        # fX, intermediate = self.model_(X, return_intermediate=self.attachment)
-
-        # # speech activity detection
-        # fX = fX.view((-1, self.n_classes_))
-
-        # target = torch.tensor(
-        #     batch['y'],
-        #     dtype=torch.int64,
-        #     device=self.device_).contiguous().view((-1, ))
-
-        # weight = self.weight
-        # if weight is not None:
-        #     weight = weight.to(device=self.device_)
-
-        # loss = self.loss_func_(fX, target, weight=weight)
-
-        # # domain classification
-        # domain_target = torch.tensor(
-        #     batch[self.domain],
-        #     dtype=torch.int64,
-        #     device=self.device_)
-
-        # domain_scores = self.activation_(self.domain_classifier_(
-        #     self.gradient_reversal_(intermediate)))
 
         loss, domain_target = super()._batch_loss(self, batch)
 

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -373,6 +373,9 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
 
         loss, domain_target = super()._batch_loss(self, batch)
 
+        domain_scores = self.activation_(self.domain_classifier_(
+            self.gradient_reversal_(intermediate)))
+        
         if self.domain_loss == "MSELoss":
             # One hot encode domain_target for Mean Squared Error Loss
             nb_domains = domain_scores.shape[1]

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -160,7 +160,7 @@ class DomainBranchSpeechActivityDetection(ABC):
         pass
 
     def _batch_loss(self, batch):
-        """Helper function to performs the common operations required for the batch_loss function 
+        """Helper function to compute loss for current `batch`
 
         Parameters
         ----------
@@ -171,7 +171,6 @@ class DomainBranchSpeechActivityDetection(ABC):
         Returns
         -------
         loss : Function f(input, target, weight=None) -> loss value
-        TO DO 
         """
         X = torch.tensor(batch['X'],
                          dtype=torch.float32,
@@ -197,11 +196,6 @@ class DomainBranchSpeechActivityDetection(ABC):
             device=self.device_)
 
         domain_scores = self.get_domain_scores(intermediate)
-        
-        # if gradient_reversal:
-        #     domain_scores = self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
-        # else:
-        #     domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
         if self.domain_loss == "MSELoss":
             # One hot encode domain_target for Mean Squared Error Loss
@@ -338,7 +332,6 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSp
 
 
     def get_domain_scores(self, intermediate):
-        print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT AWARE!!!!!!!!!!!!")
         return self.activation_(self.domain_classifier_(intermediate))
 
     def batch_loss(self, batch):
@@ -356,18 +349,9 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection, DomainBranchSp
             ['loss'] (`torch.Tensor`) : Loss
         """
 
-        #domain_scores = self.activation_(self.domain_classifier_(intermediate)) 
-
         return super()._batch_loss(batch)
-        #return self._batch_loss(batch)
 
         
-
-        #domain_loss = self.domain_loss_(domain_scores, domain_target)
-
-        # return {'loss': loss + self.alpha * domain_loss,
-        #         'loss_domain': domain_loss,
-        #         'loss_task': loss}
 
 
 class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetection):
@@ -412,6 +396,3 @@ class DomainAdversarialSpeechActivityDetection(DomainAwareSpeechActivityDetectio
         print("JAI ÉTÉ DANS L'ENFANNNNNNNNNNNNNNNT ADVERSARIAL!!!!!!!!!!!!")
         return self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
 
-        # return {'loss': loss + self.alpha * domain_loss,
-        #         'loss_domain': domain_loss,
-        #         'loss_task': loss}

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -287,12 +287,10 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
         X = torch.tensor(batch['X'],
                          dtype=torch.float32,
                          device=self.device_)
-
         fX, intermediate = self.model_(X, return_intermediate=self.attachment)
 
         # speech activity detection
         fX = fX.view((-1, self.n_classes_))
-
         target = torch.tensor(
             batch['y'],
             dtype=torch.int64,
@@ -301,7 +299,6 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
         weight = self.weight
         if weight is not None:
             weight = weight.to(device=self.device_)
-
         loss = self.loss_func_(fX, target, weight=weight)
 
         # domain classification

--- a/pyannote/audio/labeling/tasks/speech_activity_detection.py
+++ b/pyannote/audio/labeling/tasks/speech_activity_detection.py
@@ -310,7 +310,7 @@ class DomainAwareSpeechActivityDetection(SpeechActivityDetection):
 
         if gradient_reversal:
             domain_scores = self.activation_(self.domain_classifier_(self.gradient_reversal_(intermediate)))
-        else 
+        else:
             domain_scores = self.activation_(self.domain_classifier_(intermediate))
 
         if self.domain_loss == "MSELoss":


### PR DESCRIPTION
**This PR is:**
-  Fix #215 : Tentative to refactor `DomainAwareSpeechActivityDetection` and `DomainAdversarialSpeechActivityDetection` as they were sharing code in `batch_loss` 
- Add some docstrings 
- Fix #242, I added a default pooling in `DomainAwareSpeechActivityDetection` but also a message to let the user know that the pooling was chosen for him/her. I didn't know if we preferred to use a default pooling or to raise an error. 

**How I tested these changes:** 
`pip install git+https://github.com/Mymoza/pyannote-audio.git@refactor-adversarial-aware`, then I ran these tests: 

- [x] I ran `DomainAdversarialSpeechActivityDetection` with only 2 epochs (`pyannote-speech-detection train --gpu --to=2 ${EXPERIMENT_DIR} ${PROTOCOL}`) as I figured it would be enough to just test and see if training still works. I compared the log with another training I did before the refactor and I don't see anything strange.

- [x] I also ran  `DomainAwareSpeechActivityDetection` with 2 epochs as well

- [x] Also ran with `SpeechActivityDetection` 2 epochs 

 Would any other test be useful to do in order to make sure this didn't break anything? 