### PR TITLE
feat: enable to choose oracle SCD in diarization pipeline

### DIFF
--- a/pyannote/audio/pipeline/speaker_diarization.py
+++ b/pyannote/audio/pipeline/speaker_diarization.py
@@ -51,8 +51,9 @@ class SpeakerDiarization(Pipeline):
     sad_scores : `Path` or 'oracle'
         Path to precomputed speech activity detection scores.
         Use 'oracle' to assume perfect speech activity detection.
-    scd_scores : `Path`
-        Path to precomputed SCD scores on disk
+    scd_scores : `Path` or 'oracle'
+        Path to precomputed SCD scores on disk.
+        Use 'oracle' to assume perfect speaker change detection.
     embedding : `Path`
         Path to precomputed embedding on disk
     metric : {'euclidean', 'cosine', 'angular'}, optional
@@ -62,9 +63,9 @@ class SpeakerDiarization(Pipeline):
     evaluation_only : `bool`
         Only process the evaluated regions. Default to False.
     purity : `float`, optional
-        Optimize coverage for target purity. 
+        Optimize coverage for target purity.
         Defaults to optimizing diarization error rate.
-    
+
     Hyper-parameters
     ----------------
     min_duration : `float`
@@ -195,11 +196,11 @@ class SpeakerDiarization(Pipeline):
 
     def get_metric(self) -> GreedyDiarizationErrorRate:
         """Return new instance of diarization error rate metric"""
-        
+
         # defaults to optimizing diarization error rate
         if self.purity is None:
             return GreedyDiarizationErrorRate(collar=0.0, skip_overlap=False)
-        
+
         # fallbacks to using self.loss(...)
         raise NotImplementedError()
 

--- a/pyannote/audio/pipeline/speaker_diarization.py
+++ b/pyannote/audio/pipeline/speaker_diarization.py
@@ -74,7 +74,7 @@ class SpeakerDiarization(Pipeline):
     """
 
     def __init__(self, sad_scores: Optional[Union[Path, str]] = None,
-                       scd_scores: Optional[Path] = None,
+                       scd_scores: Optional[Union[Path, str]] = None,
                        embedding: Optional[Path] = None,
                        metric: Optional[str] = 'cosine',
                        method: Optional[str] = 'pool',

--- a/pyannote/audio/pipeline/speech_turn_segmentation.py
+++ b/pyannote/audio/pipeline/speech_turn_segmentation.py
@@ -68,8 +68,9 @@ class SpeechTurnSegmentation(Pipeline):
     sad_scores : `Path` or 'oracle'
         Path to precomputed speech activity detection scores.
         Use 'oracle' to assume perfect speech activity detection.
-    scd_scores : `Path`
-        Path to precomputed speaker change detection scores
+    scd_scores : `Path` or 'oracle'
+        Path to precomputed SCD scores on disk.
+        Use 'oracle' to assume perfect speaker change detection.
     non_speech : `bool`
         Mark non-speech regions as speaker change. Defaults to True.
     purity : `float`, optional

--- a/pyannote/audio/pipeline/speech_turn_segmentation.py
+++ b/pyannote/audio/pipeline/speech_turn_segmentation.py
@@ -92,7 +92,8 @@ class SpeechTurnSegmentation(Pipeline):
 
         self.scd_scores = scd_scores
         if self.scd_scores == 'oracle':
-            self.speaker_change_detection = OracleSpeechTurnSegmentation()
+            self.speaker_change_detection = None
+            self.speech_turn_segmentation = OracleSpeechTurnSegmentation()
         else:
             self.speaker_change_detection = SpeakerChangeDetection(
                 scores=self.scd_scores)
@@ -114,7 +115,10 @@ class SpeechTurnSegmentation(Pipeline):
         hypothesis : `pyannote.core.Annotation`
             Hypothesized speech turns
         """
-
+        if self.scd_scores == 'oracle':
+            speech_turns = self.speech_turn_segmentation(current_file)
+            return speech_turns
+            
         # speech regions
         sad = self.speech_activity_detection(current_file).get_timeline()
 

--- a/pyannote/audio/pipeline/speech_turn_segmentation.py
+++ b/pyannote/audio/pipeline/speech_turn_segmentation.py
@@ -90,8 +90,11 @@ class SpeechTurnSegmentation(Pipeline):
                 scores=self.sad_scores)
 
         self.scd_scores = scd_scores
-        self.speaker_change_detection = SpeakerChangeDetection(
-            scores=self.scd_scores)
+        if self.scd_scores == 'oracle':
+            self.speaker_change_detection = OracleSpeechTurnSegmentation()
+        else:            
+            self.speaker_change_detection = SpeakerChangeDetection(
+                scores=self.scd_scores)
 
         self.non_speech = non_speech
         self.purity = purity

--- a/pyannote/audio/pipeline/speech_turn_segmentation.py
+++ b/pyannote/audio/pipeline/speech_turn_segmentation.py
@@ -77,7 +77,7 @@ class SpeechTurnSegmentation(Pipeline):
     """
 
     def __init__(self, sad_scores: Optional[Union[Path, str]] = None,
-                       scd_scores: Optional[Path] = None,
+                       scd_scores: Optional[Union[Path, str]] = None,
                        non_speech: Optional[bool] = True,
                        purity: Optional[float] = 0.95):
         super().__init__()
@@ -92,7 +92,7 @@ class SpeechTurnSegmentation(Pipeline):
         self.scd_scores = scd_scores
         if self.scd_scores == 'oracle':
             self.speaker_change_detection = OracleSpeechTurnSegmentation()
-        else:            
+        else:
             self.speaker_change_detection = SpeakerChangeDetection(
                 scores=self.scd_scores)
 


### PR DESCRIPTION
# Test
After running 1 iteration with `sad_scores: oracle `and `scd_scores: oracle`, my `params.yml` file looks like this : does it seem okay to you ?

```yml
loss: 0.42706428604791596
params:
  min_duration: 0.8303121697647609
  speech_turn_assignment:
    closest_assignment:
      threshold: 2.8331183922494483
  speech_turn_clustering:
    clustering:
      damping: 0.9841757941653864
      preference: -4.145677084532185
  speech_turn_segmentation:
    speaker_change_detection: {}
    speech_activity_detection: {}
```