### PR TITLE
Debug option to detect anomalies

### DIFF
--- a/pyannote/audio/applications/pyannote_audio.py
+++ b/pyannote/audio/applications/pyannote_audio.py
@@ -171,6 +171,11 @@ Common options
 
   --gpu                   Run on GPUs. Defaults to using CPUs.
 
+  --debug                 Run using PyTorch's anomaly detection. This will throw
+                          an error if a NaN value is produced, and the stacktrace
+                          will point to the origin of it. This option can
+                          considerably slow execution.
+
   --from=<epoch>          Start training (resp. validating) at epoch <epoch>.
                           Use --from=last to start from last available epoch at
                           launch time. Not used for inference [default: 0].
@@ -246,6 +251,7 @@ Validation options
 """
 
 import sys
+import warnings
 from docopt import docopt
 from pathlib import Path
 import multiprocessing
@@ -286,6 +292,10 @@ def main():
 
     protocol = arg['<protocol>']
     subset = arg['--subset']
+
+    if arg['--debug']:
+        warnings.warn('Debug mode is enabled, this option might slow execution considerably', RuntimeWarning)
+        torch.autograd.set_detect_anomaly(True)
 
     n_jobs = arg['--parallel']
     if n_jobs is None:

--- a/pyannote/audio/applications/pyannote_audio.py
+++ b/pyannote/audio/applications/pyannote_audio.py
@@ -294,7 +294,8 @@ def main():
     subset = arg['--subset']
 
     if arg['--debug']:
-        warnings.warn('Debug mode is enabled, this option might slow execution considerably', RuntimeWarning)
+        msg = 'Debug mode is enabled, this option might slow execution considerably.'
+        warnings.warn(msg, RuntimeWarning)
         torch.autograd.set_detect_anomaly(True)
 
     n_jobs = arg['--parallel']


### PR DESCRIPTION
## Changelog
- New `--debug` option to use PyTorch's anomaly detection when executing
  - This raises errors when NaN values are found (and they point to the actual line where they appear)
  - A warning is shown to the user when the option is activated, as execution can be slowed down