### PR TITLE
feat: add support for cannot_link constraints in turn-level clustering

### DIFF
--- a/pyannote/audio/pipeline/speech_turn_clustering.py
+++ b/pyannote/audio/pipeline/speech_turn_clustering.py
@@ -171,7 +171,7 @@ class SpeechTurnClustering(Pipeline):
             Speech turns.
         cannot_link : `dict`, optional
             Clustering constraints, a dict like:
-            {Segment : List[Segment]}, where segments should not be clustered together
+            {Segment : Set[Segment]}, where segments should not be clustered together
             Defaults to no constraints (i.e. None)
 
         Returns

--- a/pyannote/audio/pipeline/speech_turn_clustering.py
+++ b/pyannote/audio/pipeline/speech_turn_clustering.py
@@ -227,10 +227,7 @@ class SpeechTurnClustering(Pipeline):
             mapping[label] = -(l + 1)
 
         # do the actual mapping
-        speech_turns.rename_labels(mapping=mapping, copy=False)
-        # keep original labels for identified speakers
-        speech_turns.rename_labels(mapping=identities, copy=False)
-        return speech_turns
+        return speech_turns.rename_labels(mapping=mapping)
 
     def __call__(
         self, current_file: dict, speech_turns: Optional[Annotation] = None,


### PR DESCRIPTION
Hey, again I don't expect you to merge this.
I'm not sure that you'll like the cannot_link `dict` format...

PS: I haven't tested none of this or my other PRs yet