### PR TITLE
small corrections in validation step

### DIFF
--- a/tutorials/models/speech_activity_detection/README.md
+++ b/tutorials/models/speech_activity_detection/README.md
@@ -156,7 +156,7 @@ It can be run while the model is still training and evaluates the model every 10
 In practice, it tunes a simple speech activity detection pipeline every 10 epochs and stores the best hyper-parameter configuration on disk (i.e. the one that maximizes detection f-score):
 
 ```bash
-$ export VAL_DIR = ${TRN_DIR}/validate/AMI.SpeakerDiarization.MixHeadset.development
+$ export VAL_DIR=${TRN_DIR}/validate/AMI.SpeakerDiarization.MixHeadset.development
 $ cat ${VAL_DIR}/params.yml
 ```
 ```yaml


### PR DESCRIPTION
Removed spaces around '=' sign

$ export VAL_DIR = ${TRN_DIR}/validate/AMI.SpeakerDiarization.MixHeadset.development ,

otherwise `bash: export: `=': not a valid identifier` is thrown