### PR TITLE
More kwargs of torch.hub.load

### DIFF
--- a/tutorials/pretrained/model/README.md
+++ b/tutorials/pretrained/model/README.md
@@ -41,7 +41,8 @@ ovl = torch.hub.load('pyannote/pyannote-audio', 'ovl_ami')
 emb = torch.hub.load('pyannote/pyannote-audio', 'emb_ami')
 ```
 
-The pulled models will be on GPU by default if one is available. We can also have more control by specifying other kwargs provided by `torch.hub.load`, e.g.:
+Note that models will run on GPU by default if one is available.  
+Both device and batch size can be specified manually if needed: 
 ```python
 sad = torch.hub.load('pyannote/pyannote-audio', 'sad_ami', device='cpu', batch_size=128)
 ```


### PR DESCRIPTION
Adding example of specifying batch_size or device when pulling models from torch.hub