### PR TITLE
Add torch.no_grad() during inference time

### DIFF
--- a/pyannote/audio/features/pretrained.py
+++ b/pyannote/audio/features/pretrained.py
@@ -136,8 +136,7 @@ class Pretrained(FeatureExtraction):
         self.device = torch.device(device)
 
         # send model to device
-        with torch.no_grad():
-            self.model_ = model.eval().to(self.device)
+        self.model_ = model.eval().to(self.device)
 
         # initialize chunks duration with that used during training
         self.duration = getattr(config["task"], "duration", None)

--- a/pyannote/audio/features/pretrained.py
+++ b/pyannote/audio/features/pretrained.py
@@ -136,7 +136,8 @@ class Pretrained(FeatureExtraction):
         self.device = torch.device(device)
 
         # send model to device
-        self.model_ = model.eval().to(self.device)
+        with torch.no_grad():
+            self.model_ = model.eval().to(self.device)
 
         # initialize chunks duration with that used during training
         self.duration = getattr(config["task"], "duration", None)

--- a/pyannote/audio/train/model.py
+++ b/pyannote/audio/train/model.py
@@ -465,7 +465,8 @@ class Model(Module):
             tX = torch.tensor(batch["X"], dtype=torch.float32, device=device)
 
             # FIXME: fix support for return_intermediate
-            tfX = self(tX, return_intermediate=return_intermediate)
+            with torch.no_grad():
+                tfX = self(tX, return_intermediate=return_intermediate)
 
             tfX_npy = tfX.detach().to("cpu").numpy()
             if postprocess is not None:


### PR DESCRIPTION
Following [this tutorial](https://github.com/pyannote/pyannote-audio/tree/develop/tutorials/pretrained/model) which consists of running a model pretrained on AMI reduced the memory from 5274.61 Mb (without **torch.no_grad()**) to 1691.49 Mb (with it).