### PR TITLE
feat: add support for torch_audiomentations waveform transforms

### DIFF
--- a/pyannote/audio/cli/train.py
+++ b/pyannote/audio/cli/train.py
@@ -45,7 +45,7 @@ def main(cfg: DictConfig) -> None:
     def optimizer(parameters: Iterable[Parameter], lr: float = 1e-3) -> Optimizer:
         return instantiate(cfg.optimizer, parameters, lr=lr)
 
-    augmentation = instantiate(cfg.augmentation)
+    augmentation = instantiate(cfg.augmentation) if "augmentation" in cfg else None
 
     task = instantiate(
         cfg.task,

--- a/pyannote/audio/cli/train.py
+++ b/pyannote/audio/cli/train.py
@@ -39,18 +39,20 @@ def main(cfg: DictConfig) -> None:
 
     protocol = get_protocol(cfg.protocol, preprocessors={"audio": FileFinder()})
 
-    # TODO: configure augmentation
     # TODO: configure scheduler
     # TODO: configure layer freezing
 
     def optimizer(parameters: Iterable[Parameter], lr: float = 1e-3) -> Optimizer:
         return instantiate(cfg.optimizer, parameters, lr=lr)
 
+    augmentation = instantiate(cfg.augmentation)
+
     task = instantiate(
         cfg.task,
         protocol,
         optimizer=optimizer,
         learning_rate=cfg.optimizer.lr,
+        augmentation=augmentation,
     )
 
     model = instantiate(cfg.model, task=task)

--- a/pyannote/audio/cli/train_config/augmentation/background.yaml
+++ b/pyannote/audio/cli/train_config/augmentation/background.yaml
@@ -1,0 +1,10 @@
+# @package _group_
+_target_: torch_audiomentations.utils.config.from_dict
+config:
+    transform: ApplyBackgroundNoise
+    params:
+        background_paths: ???
+        min_snr_in_db: 5.
+        max_snr_in_db: 20.
+        mode: per_example
+        p: 1.0

--- a/pyannote/audio/tasks/segmentation/multi_task_segmentation.py
+++ b/pyannote/audio/tasks/segmentation/multi_task_segmentation.py
@@ -27,6 +27,7 @@ from typing import Callable, Iterable, Mapping
 import numpy as np
 from torch.nn import Parameter
 from torch.optim import Optimizer
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 
 from pyannote.audio.core.io import Audio
 from pyannote.audio.core.task import Task
@@ -90,6 +91,10 @@ class MultiTaskSegmentation(SegmentationTaskMixin, Task):
         an Optimizer instance. Defaults to `torch.optim.Adam`.
     learning_rate : float, optional
         Learning rate. Defaults to 1e-3.
+    augmentation : BaseWaveformTransform, optional
+        torch_audiomentations waveform transform, used by dataloader
+        during training.
+
     """
 
     def __init__(
@@ -107,6 +112,7 @@ class MultiTaskSegmentation(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         super().__init__(
@@ -117,6 +123,7 @@ class MultiTaskSegmentation(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         self.vad = vad

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -27,6 +27,7 @@ from typing import Callable, Iterable
 import numpy as np
 from torch.nn import Parameter
 from torch.optim import Optimizer
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 
 from pyannote.audio.core.io import Audio
 from pyannote.audio.core.task import Problem, Scale, Task, TaskSpecification
@@ -80,6 +81,9 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         an Optimizer instance. Defaults to `torch.optim.Adam`.
     learning_rate : float, optional
         Learning rate. Defaults to 1e-3.
+    augmentation : BaseWaveformTransform, optional
+        torch_audiomentations waveform transform, used by dataloader
+        during training.
     """
 
     def __init__(
@@ -95,6 +99,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         super().__init__(
@@ -105,6 +110,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         self.specifications = TaskSpecification(

--- a/pyannote/audio/tasks/segmentation/speaker_change_detection.py
+++ b/pyannote/audio/tasks/segmentation/speaker_change_detection.py
@@ -26,6 +26,7 @@ import numpy as np
 import scipy.signal
 from torch.nn import Parameter
 from torch.optim import Optimizer
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 
 from pyannote.audio.core.task import Problem, Scale, Task, TaskSpecification
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -66,6 +67,9 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
         an Optimizer instance. Defaults to `torch.optim.Adam`.
     learning_rate : float, optional
         Learning rate. Defaults to 1e-3.
+    augmentation : BaseWaveformTransform, optional
+        torch_audiomentations waveform transform, used by dataloader
+        during training.
     """
 
     def __init__(
@@ -78,6 +82,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         super().__init__(
@@ -88,6 +93,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         self.specifications = TaskSpecification(

--- a/pyannote/audio/tasks/segmentation/speaker_tracking.py
+++ b/pyannote/audio/tasks/segmentation/speaker_tracking.py
@@ -24,6 +24,7 @@ from typing import Callable, Iterable, List, Text
 
 from torch.nn import Parameter
 from torch.optim import Optimizer
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 
 from pyannote.audio.core.task import Problem, Scale, Task, TaskSpecification
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -59,6 +60,9 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
         an Optimizer instance. Defaults to `torch.optim.Adam`.
     learning_rate : float, optional
         Learning rate. Defaults to 1e-3.
+    augmentation : BaseWaveformTransform, optional
+        torch_audiomentations waveform transform, used by dataloader
+        during training.
     """
 
     def __init__(
@@ -70,6 +74,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         super().__init__(
@@ -80,6 +85,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         # for speaker tracking, task specification depends

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -25,6 +25,7 @@ from typing import Callable, Iterable
 import numpy as np
 from torch.nn import Parameter
 from torch.optim import Optimizer
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 
 from pyannote.audio.core.task import Problem, Scale, Task, TaskSpecification
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -59,6 +60,9 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         an Optimizer instance. Defaults to `torch.optim.Adam`.
     learning_rate : float, optional
         Learning rate. Defaults to 1e-3.
+    augmentation : BaseWaveformTransform, optional
+        torch_audiomentations waveform transform, used by dataloader
+        during training.
     """
 
     def __init__(
@@ -70,6 +74,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         super().__init__(
@@ -80,6 +85,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         self.specifications = TaskSpecification(

--- a/pyannote/audio/tasks/speaker_verification/task.py
+++ b/pyannote/audio/tasks/speaker_verification/task.py
@@ -39,6 +39,8 @@ from pyannote.database import Protocol
 if TYPE_CHECKING:
     from pyannote.audio.core.model import Model
 
+from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+
 
 class SpeakerEmbeddingArcFace(Task):
     """
@@ -71,6 +73,7 @@ class SpeakerEmbeddingArcFace(Task):
         pin_memory: bool = False,
         optimizer: Callable[[Iterable[Parameter]], Optimizer] = None,
         learning_rate: float = 1e-3,
+        augmentation: BaseWaveformTransform = None,
     ):
 
         self.num_chunks_per_speaker = num_chunks_per_speaker
@@ -86,6 +89,7 @@ class SpeakerEmbeddingArcFace(Task):
             pin_memory=pin_memory,
             optimizer=optimizer,
             learning_rate=learning_rate,
+            augmentation=augmentation,
         )
 
         # there is no such thing as a "class" in representation

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytorch_metric_learning >= 0.9.93
 semver >= 2.10.2
 soundfile >= 0.10.2
 torch >= 1.6
-torch-audiomentations == 0.5
+torch-audiomentations >= 0.4
 torchaudio >= 0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytorch_metric_learning >= 0.9.93
 semver >= 2.10.2
 soundfile >= 0.10.2
 torch >= 1.6
-torch-audiomentations >= 0.2
+torch-audiomentations == 0.5
 torchaudio >= 0.6


### PR DESCRIPTION
@mogwai, I went with a simple (simplistic?) support of torch_audiomentations waveform transforms, by overriding the dataloader's collate function.