### PR TITLE
feat: use Kaiser window for inference overlap-add aggregation

### DIFF
--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -264,6 +264,7 @@ class Inference:
 
         for t, (task_name, task_specifications) in enumerate(self.task_specifications):
             # if model outputs just one vector per chunk, return the outputs as they are
+            #  (i.e. do not aggregate them)
             if task_specifications.scale == Scale.CHUNK:
                 frames = SlidingWindow(
                     start=0.0, duration=self.duration, step=self.step
@@ -283,34 +284,40 @@ class Inference:
             num_frames, dimension = model_introspection(num_samples)
             num_frames_per_chunk, _ = model_introspection(window_size)
 
-            # aggregated_output[i] will be used to store the sum of all predictions for frame #i
+            # hamming window used for overlap-add aggregation
+            hamming = np.hamming(num_frames_per_chunk)
+
+            # aggregated_output[i] will be used to store the (hamming-weighted) sum
+            # of all predictions for frame #i
             aggregated_output: np.ndarray = np.zeros(
                 (num_frames, dimension), dtype=np.float32
             )
 
-            # overlapping_chunk_count[i] will be used to store the number of chunks that
-            # overlap with frame #i
+            # overlapping_chunk_count[i] will be used to store the (hamming-weighted)
+            # number of chunks that overlap with frame #i
             overlapping_chunk_count: np.ndarray = np.zeros(
-                (num_frames, 1), dtype=np.int32
+                (num_frames, 1), dtype=np.float32
             )
 
             # loop on the outputs of sliding chunks
             for c, output in enumerate(outputs[task_name]):
                 start_sample = c * step_size
                 start_frame, _ = model_introspection(start_sample)
-                aggregated_output[
-                    start_frame : start_frame + num_frames_per_chunk
-                ] += output
+                aggregated_output[start_frame : start_frame + num_frames_per_chunk] += (
+                    output * hamming
+                )
                 overlapping_chunk_count[
                     start_frame : start_frame + num_frames_per_chunk
-                ] += 1
+                ] += hamming
 
             # process last (right-aligned) chunk separately
             if has_last_chunk:
-                aggregated_output[-num_frames_per_chunk:] += last_output[task_name]
-                overlapping_chunk_count[-num_frames_per_chunk:] += 1
+                aggregated_output[-num_frames_per_chunk:] += (
+                    last_output[task_name] * hamming
+                )
+                overlapping_chunk_count[-num_frames_per_chunk:] += hamming
 
-            aggregated_output /= np.maximum(overlapping_chunk_count, 1)
+            aggregated_output /= overlapping_chunk_count
 
             frames = SlidingWindow(
                 start=0,

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -285,7 +285,7 @@ class Inference:
             num_frames_per_chunk, _ = model_introspection(window_size)
 
             # hamming window used for overlap-add aggregation
-            hamming = np.hamming(num_frames_per_chunk)
+            hamming = np.hamming(num_frames_per_chunk).reshape(-1, 1)
 
             # aggregated_output[i] will be used to store the (hamming-weighted) sum
             # of all predictions for frame #i


### PR DESCRIPTION
Segmentation models tend to work better at the center of an audio chunk than at its boundaries.
![image](https://user-images.githubusercontent.com/1080837/100081582-7b3bbb80-2e47-11eb-99c8-018becd9c6fb.png)

Therefore, using this window, we give more weights to the center than to the boundaries when aggregating overlapping chunks. 
<img width="370" alt="image" src="https://user-images.githubusercontent.com/1080837/100081804-be962a00-2e47-11eb-9f25-8ad9f7200cca.png">

While it was not that important in pyannote.audio 1.1 because scores were aggregated in the log-domain (where low scores quickly become almost zero), it is needed in pyannote.audio 2.0 because scores are aggregated in the [0, 1]  domain.

Hence, without this window, one would notice overlap artifacts:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/1080837/100082096-159bff00-2e48-11eb-9a98-a164fe3ca1f9.png">

which are completely gone with the addition of the window:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/1080837/100082249-49772480-2e48-11eb-86c6-945e953df095.png">


