### PR TITLE
fix: handle Audio.crop corner case with small rounding error

### DIFF
--- a/pyannote/audio/core/io.py
+++ b/pyannote/audio/core/io.py
@@ -90,6 +90,8 @@ class Audio:
     >>> assert waveform.shape[0] == 1
     """
 
+    PRECISION = 0.001
+
     @staticmethod
     def power_normalize(waveform: Tensor) -> Tensor:
         """Power-normalize waveform
@@ -321,20 +323,45 @@ class Audio:
             frames = info.num_frames
 
         # infer which samples to load from sample rate and requested chunk
-        start_frame = int(segment.start * sample_rate)
+        start_frame = round(segment.start * sample_rate)
 
         if fixed:
+
             num_frames = math.floor(fixed * sample_rate)
+
+            if num_frames > frames:
+                raise ValueError(
+                    f"requested fixed duration ({fixed:6f}s, or {num_frames:d} frames) is longer "
+                    f"than file duration ({frames / sample_rate:.6f}s, or {frames:d} frames)."
+                )
+
+            end_frame = start_frame + num_frames
+
+            # raise an error if it "out-of-bounds" by more than precision
+            if end_frame > frames + math.ceil(self.PRECISION * sample_rate):
+                raise ValueError(
+                    f"requested chunk [{segment.start:.6f}, {segment.end:.6f}] ({start_frame:d}:{end_frame:d}) "
+                    f"lies outside of file bounds [0., {frames / sample_rate:.6f}] (0:{frames:d})."
+                )
+
+            # shift chunk to the left if it "out-of-bounds" by less than precision
+            end_frame = min(end_frame, frames)
+            start_frame = end_frame - num_frames
+
         else:
-            num_frames = math.floor(segment.end * sample_rate - start_frame)
 
-        end_frame = start_frame + num_frames
+            end_frame = math.floor(segment.end * sample_rate)
 
-        if start_frame < 0 or end_frame > frames:
-            raise ValueError(
-                f"requested chunk [{segment.start:.6f}, {segment.end:.6f}] "
-                f"lies outside of file bounds [0., {frames / sample_rate:.6f}]."
-            )
+            # raise an error if it "out-of-bounds" by more than precision
+            if end_frame > frames + math.ceil(self.PRECISION * sample_rate):
+                raise ValueError(
+                    f"requested chunk [{segment.start:.6f}, {segment.end:.6f}] ({start_frame:d}:{end_frame:d}) "
+                    f"lies outside of file bounds [0., {frames / sample_rate:.6f}] (0:{frames:d})."
+                )
+
+            # crop chunk if it "out-of-bounds" by less than precision
+            end_frame = min(end_frame, frames)
+            num_frames = end_frame - start_frame
 
         if waveform is not None:
             data = waveform[:, start_frame:end_frame]


### PR DESCRIPTION
As I expected, I stumbled upon out-of-bounds errors in `Audio.crop` when training large scale models.
These errors result from small rounding errors due to the time-to-frame conversion.