### PR TITLE
chore: torchaudio >= 0.7.0 and the new sox_io interface

### DIFF
--- a/pyannote/audio/core/io.py
+++ b/pyannote/audio/core/io.py
@@ -63,9 +63,8 @@ integer to load a specific channel:
         {"audio": Path("/path/to/stereo.wav"), "channel": 0}
 """
 
-# TODO: Remove this when it is the default
-torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False
-torchaudio.set_audio_backend("soundfile")
+# TODO: Remove this when it is the default in torchaudio 0.8.0
+torchaudio.set_audio_backend("sox_io")
 
 
 class Audio:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ semver >= 2.10.2
 soundfile >= 0.10.2
 torch >= 1.6
 torch-audiomentations >= 0.4
-torchaudio >= 0.6
+torchaudio >= 0.7
 typing_extensions >= 3.7.4.3


### PR DESCRIPTION
I've increased the required version of torchaudio required to run pyannote from `0.6.0` to `0.7.0.

I've also set the backend to use to be the new `sox_io` instead of the `soundfile` interface. 

This is to prepare for the coming changing in `0.8.0` that will make `sox_io` the default. 