### PR TITLE
feat: add support for weighted statistics pooling

### DIFF
--- a/pyannote/audio/models/blocks/pooling.py
+++ b/pyannote/audio/models/blocks/pooling.py
@@ -20,26 +20,66 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+from typing import Optional
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 
 class StatsPool(nn.Module):
     """Statistics pooling
 
-    Returns the concatenated mean and standard deviation (over time)
+    Compute temporal mean and (unbiased) standard deviation
+    and returns their concatenation.
+
+    Reference
+    ---------
+    https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
+
     """
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
+    def forward(
+        self, sequences: torch.Tensor, weights: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Forward pass
 
         Parameters
         ----------
-        x : (batch, channel, time) torch.Tensor
+        sequences : (batch, channel, frames) torch.Tensor
+            Sequences.
+        weights : (batch, frames) torch.Tensor, optional
+            When provided, compute weighted mean and standard deviation.
 
         Returns
         -------
         output : (batch, 2 * channel) torch.Tensor
+            Concatenation of mean and (unbiased) standard deviation.
         """
-        return torch.cat([x.mean(dim=2), x.std(dim=2)], dim=1)
+
+        if weights is None:
+            mean = sequences.mean(dim=2)
+            std = sequences.std(dim=2, unbiased=True)
+
+        else:
+            weights = weights.unsqueeze(dim=1)
+
+            num_frames = sequences.shape[2]
+            num_weights = weights.shape[2]
+            if num_frames != num_weights:
+                warnings.warn(
+                    f"Mismatch between frames ({num_frames}) and weights ({num_weights}) numbers."
+                )
+                weights = F.interpolate(weights, size=num_frames, mode="nearest")
+
+            v1 = weights.sum(dim=2)
+            mean = torch.sum(sequences * weights, dim=2) / v1
+
+            dx2 = torch.square(sequences - mean.unsqueeze(2))
+            v2 = torch.square(weights).sum(dim=2)
+
+            var = torch.sum(dx2 * weights, dim=2) / (v1 - v2 / v1)
+            std = torch.sqrt(var)
+
+        return torch.cat([mean, std], dim=1)

--- a/pyannote/audio/models/embedding/xvector.py
+++ b/pyannote/audio/models/embedding/xvector.py
@@ -84,13 +84,17 @@ class XVectorMFCC(Model):
         self.segment6 = nn.Linear(3000, 512)
         self.segment7 = nn.Linear(512, 512)
 
-    def forward(self, waveforms: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, waveforms: torch.Tensor, weights: torch.Tensor = None
+    ) -> torch.Tensor:
         """
 
         Parameters
         ----------
-        waveforms : (batch, channel, sample)
-
+        waveforms : torch.Tensor
+            Batch of waveforms with shape (batch, channel, sample)
+        weights : torch.Tensor, optional
+            Batch of weights with shape (batch, frame).
         """
 
         outputs = self.mfcc(waveforms).squeeze(dim=1)
@@ -99,7 +103,7 @@ class XVectorMFCC(Model):
         outputs = self.frame3(outputs)
         outputs = self.frame4(outputs)
         outputs = self.frame5(outputs)
-        outputs = self.stats_pool(outputs)
+        outputs = self.stats_pool(outputs, weights=weights)
         outputs = self.segment6(F.relu(outputs))
         return self.segment7(F.relu(outputs))
 
@@ -154,13 +158,17 @@ class XVector(Model):
         self.segment6 = nn.Linear(3000, 512)
         self.segment7 = nn.Linear(512, 512)
 
-    def forward(self, waveforms: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, waveforms: torch.Tensor, weights: torch.Tensor = None
+    ) -> torch.Tensor:
         """
 
         Parameters
         ----------
-        waveforms : (batch, channel, sample)
-
+        waveforms : torch.Tensor
+            Batch of waveforms with shape (batch, channel, sample)
+        weights : torch.Tensor, optional
+            Batch of weights with shape (batch, frame).
         """
 
         outputs = self.sincnet(waveforms)
@@ -169,6 +177,6 @@ class XVector(Model):
         outputs = self.frame3(outputs)
         outputs = self.frame4(outputs)
         outputs = self.frame5(outputs)
-        outputs = self.stats_pool(outputs)
+        outputs = self.stats_pool(outputs, weights=weights)
         outputs = self.segment6(F.relu(outputs))
         return self.segment7(F.relu(outputs))


### PR DESCRIPTION
cc @juanmc2005 

This PR allows the statistics pooling layer in xvector-like speaker embedding to give more weights to regions where the probability that a speaker is active is higher.  Let's discuss why this might be useful for you offline in our Slack channel.

```python
from pyannote.audio import Model
speaker_embedding = Model.from_pretrained('hbredin/SpeakerEmbedding-XVectorMFCC-VoxCeleb')
voice_activity_detection = Model.from_pretrained('hbredin/VoiceActivityDetection-PyanNet-DIHARD')

from pyannote.audio.core.io import Audio
audio = Audio(sample_rate=16000)

from pyannote.core import Segment
chunk = Segment(5, 10)

waveform, _ = audio.crop(file, chunk)
waveforms = waveform.unsqueeze(0)

# performs VAD on [5-10] chunk
vad = voice_activity_detection(waveforms)
# extract embedding from the same chunk but give more weights to where speaker is active
emb = speaker_embedding(waveforms, weights=vad.squeeze(2))
```
