### PR TITLE
feat: make finetuning (or transfer learning) of pretrained models easier and more reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,25 +100,16 @@ model.task = osd
 trainer.fit(model)
 ```
 
-Default optimizer (`Adam` with default parameters) is automatically set up for you.  Customizing optimizer (and scheduler) requires a bit more work:
+Default optimizer (`Adam` with default parameters) is automatically set up for you.  Customizing optimizer (and scheduler) requires overriding [`model.configure_optimizers`](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.core.lightning.html#pytorch_lightning.core.lightning.LightningModule.configure_optimizers) method:
 
 ```python
-import torch.optim
-task.setup(stage="fit")
-model.setup(stage="fit")
-model.optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
-model.scheduler = torch.optim.lr_scheduler.ExponentialLR(model.optimizer, 0.9)
-trainer.fit(model)
-```
-
-If you feel adventurous or need more flexibility, you may override [`model.configure_optimizers`](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.core.lightning.html#pytorch_lightning.core.lightning.LightningModule.configure_optimizers) method:
-
-```python
-def custom_configure_optimizers(self):
-    optimizer = torch.optim.SGD(self.parameters(), lr=1e-3)
-    scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, 0.9)
-    return {"optimizer": optimizer, "lr_scheduler": scheduler}
-model.configure_optimizers = custom_configure_optimizers
+from types import MethodType
+from torch.optim import SGD
+from torch.optim.lr_scheduler import ExponentialLR
+def configure_optimizers(self):
+    return {"optimizer": SGD(self.parameters()),
+            "lr_scheduler": ExponentialLR(optimizer, 0.9)}
+model.configure_optimizers = MethodType(configure_optimizers, model)
 trainer.fit(model)
 ```
 

--- a/pyannote/audio/cli/pretrained.py
+++ b/pyannote/audio/cli/pretrained.py
@@ -23,16 +23,11 @@
 
 from typing import Text
 
-import torch
-
 from pyannote.audio import Model
 from pyannote.audio.core.task import Task
 
 
 def pretrained(checkpoint: Text, task: Task = None):
-    model = Model.from_pretrained(
-        checkpoint,
-        map_location=torch.device("cpu"),
-        task=task,
+    return Model.from_pretrained(
+        checkpoint, task=task, map_location=lambda storage, loc: storage
     )
-    return model

--- a/pyannote/audio/cli/pretrained.py
+++ b/pyannote/audio/cli/pretrained.py
@@ -26,9 +26,13 @@ from typing import Text
 import torch
 
 from pyannote.audio import Model
+from pyannote.audio.core.task import Task
 
 
-def pretrained(checkpoint: Text):
-    return Model.from_pretrained(
-        checkpoint, map_location=torch.device("cpu"), strict=False
+def pretrained(checkpoint: Text, task: Task = None):
+    model = Model.from_pretrained(
+        checkpoint,
+        map_location=torch.device("cpu"),
+        task=task,
     )
+    return model

--- a/pyannote/audio/cli/train.py
+++ b/pyannote/audio/cli/train.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import os
+from types import MethodType
 from typing import Optional
 
 import hydra
@@ -69,27 +70,31 @@ def main(cfg: DictConfig) -> Optional[float]:
         else None
     )
 
-    # instantiate task
+    # instantiate task and validation metric
     task = instantiate(cfg.task, protocol, augmentation=augmentation)
-
-    model = instantiate(cfg.model)
-    model.task = task
-
-    # setup optimizer and scheduler
-    task.setup(stage="fit")
-    model.setup(stage="fit")
-
-    model.optimizer = instantiate(cfg.optimizer, model.parameters())
-
     monitor, direction = task.val_monitor
 
-    # TODO: allow configuring scheduler
-    if monitor is None:
-        model.scheduler = None
-    else:
-        model.scheduler = {
+    # instantiate model
+    pretrained = cfg.model["_target_"] == "pyannote.audio.cli.pretrained"
+    model = instantiate(cfg.model, task=task)
+
+    if not pretrained:
+        # add task-dependent layers so that later call to model.parameters()
+        # does return all layers (even task-dependent ones). this is already
+        # done for pretrained models (TODO: check that this is true)
+        task.setup(stage="fit")
+        model.setup(stage="fit")
+
+    def configure_optimizers(self):
+
+        optimizer = instantiate(cfg.optimizer, self.parameters())
+
+        if monitor is None:
+            return optimizer
+
+        lr_scheduler = {
             "scheduler": ReduceLROnPlateau(
-                model.optimizer,
+                optimizer,
                 mode=direction,
                 factor=0.5,
                 patience=20,
@@ -105,12 +110,14 @@ def main(cfg: DictConfig) -> Optional[float]:
             "monitor": monitor,
             "strict": True,
         }
+        return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+    model.configure_optimizers = MethodType(configure_optimizers, model)
 
     callbacks = []
 
-    if model.scheduler is not None:
-        learning_rate_monitor = LearningRateMonitor(logging_interval="step")
-        callbacks.append(learning_rate_monitor)
+    learning_rate_monitor = LearningRateMonitor(logging_interval="step")
+    callbacks.append(learning_rate_monitor)
 
     checkpoint = ModelCheckpoint(
         monitor=monitor,
@@ -146,6 +153,9 @@ def main(cfg: DictConfig) -> Optional[float]:
     # TODO: defaults to one-GPU training (one GPU is available)
 
     trainer = instantiate(cfg.trainer, callbacks=callbacks, logger=logger)
+
+    # TODO: make sure that (potentially computationnally expensive task.setup(fit) is not called twice)
+
     trainer.fit(model)
 
     # save paths to best models

--- a/pyannote/audio/core/callback.py
+++ b/pyannote/audio/core/callback.py
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2020-2021 CNRS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from pytorch_lightning import Callback, Trainer
+
+from pyannote.audio import Model
+
+
+class GraduallyUnfreeze(Callback):
+    """Gradually unfreeze layers
+
+    1. Freezes all layers but those that depends on the task.
+    2. Waits for a few training epochs to pass.
+    3. Unfreezes all layers.
+
+    Parameters
+    ----------
+    patience : int, optional
+        Wait for that many epochs before unfreezing all layers.
+        Defaults to 1.
+    """
+
+    def __init__(self, patience: int = 1):
+        super().__init__()
+        self.patience = patience
+
+    def on_fit_start(self, trainer: Trainer, model: Model):
+        self._task_independent_layers = [
+            name
+            for name, _ in model.named_modules()
+            if name not in model.task_dependent and name != ""
+        ]
+        _ = model.freeze_by_name(self._task_independent_layers)
+
+    def on_train_epoch_start(self, trainer: Trainer, model: Model):
+        if trainer.current_epoch == self.patience:
+            _ = model.unfreeze_by_name(self._task_independent_layers)

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -501,32 +501,8 @@ class Model(pl.LightningModule):
     def validation_epoch_end(self, outputs):
         return self.task.validation_epoch_end(outputs)
 
-    @property
-    def optimizer(self):
-        if not hasattr(self, "_optimizer"):
-            self._optimizer = torch.optim.Adam(self.parameters(), lr=1e-3)
-        return self._optimizer
-
-    @optimizer.setter
-    def optimizer(self, optimizer):
-        self._optimizer = optimizer
-
-    @property
-    def scheduler(self):
-        if not hasattr(self, "_scheduler"):
-            self._scheduler = None
-        return self._scheduler
-
-    @scheduler.setter
-    def scheduler(self, scheduler):
-        self._scheduler = scheduler
-
     def configure_optimizers(self):
-        scheduler = self.scheduler
-        if scheduler is None:
-            return self.optimizer
-
-        return {"optimizer": self.optimizer, "lr_scheduler": self.scheduler}
+        return torch.optim.Adam(self.parameters(), lr=1e-3)
 
     def _helper_up_to(
         self, module_name: Text, requires_grad: bool = False
@@ -551,6 +527,7 @@ class Model(pl.LightningModule):
 
             for parameter in module.parameters(recurse=True):
                 parameter.requires_grad = requires_grad
+            module.train(mode=requires_grad)
 
             updated_modules.append(name)
 
@@ -634,6 +611,7 @@ class Model(pl.LightningModule):
 
             for parameter in module.parameters(recurse=True):
                 parameter.requires_grad = requires_grad
+            module.train(requires_grad)
 
             # keep track of updated modules
             updated_modules.append(name)

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -645,7 +645,9 @@ class Model(pl.LightningModule):
         return updated_modules
 
     def freeze_by_name(
-        self, modules: Union[Text, List[Text]], recurse: bool = True
+        self,
+        modules: Union[Text, List[Text]],
+        recurse: bool = True,
     ) -> List[Text]:
         """Freeze modules
 
@@ -674,7 +676,9 @@ class Model(pl.LightningModule):
         )
 
     def unfreeze_by_name(
-        self, modules: Union[List[Text], Text], recurse: bool = True
+        self,
+        modules: Union[List[Text], Text],
+        recurse: bool = True,
     ) -> List[Text]:
         """Unfreeze modules
 
@@ -682,6 +686,9 @@ class Model(pl.LightningModule):
         ----------
         modules : list of str, str
             Name(s) of modules to unfreeze
+        recurse : bool, optional
+            If True (default), unfreezes parameters of these modules and all submodules.
+            Otherwise, only unfreezes parameters that are direct members of these modules.
 
         Returns
         -------


### PR DESCRIPTION
- feat: track task-dependent layers (i.e. layers that are completely reset when switching task)
- feat: add finetuning / transfer learning callback and use it in CLI
- fix: remove (broken) support for setting `Model.{optimizer, scheduler}` attributes
- doc: update README and CLI to reflect the above fix
