### PR TITLE
feat: Augmentations on the GPU

### DIFF
--- a/pyannote/audio/augmentation/registry.py
+++ b/pyannote/audio/augmentation/registry.py
@@ -19,23 +19,21 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-
-from torch.nn import Module, ModuleDict
+import torch.nn as nn
 
 
 def register_augmentation(
-    augmentation: Module,
-    module: Module,
+    augmentation: nn.Module,
+    module: nn.Module,
     when: str = "input",
 ):
     """Register augmentation
 
     Parameters
     ----------
-    augmentation : Module
+    augmentation : nn.Module
         Augmentation module.
-    module : Module
+    module : nn.Module
         Module whose input or output should be augmented.
     when : {'input', 'output'}
         Whether to apply augmentation on the input or the output.
@@ -44,7 +42,7 @@ def register_augmentation(
     Usage
     -----
 
-    class Net(Module):
+    class Net(nn.Module):
         def __init__(self):
             super().__init__()
             self.spectogram = Spectrogram()
@@ -56,7 +54,7 @@ def register_augmentation(
 
     net = Net()
 
-    class AddNoise(Module):
+    class AddNoise(nn.Module):
         def forward(self, waveforms):
             if not self.training:
                 return waveforms
@@ -67,7 +65,7 @@ def register_augmentation(
     # AddNoise will be automatically applied to `net` input
     register_augmentation(AddNoise(), net, when='input')
 
-    class SpecAugment(Module):
+    class SpecAugment(nn.Module):
         def forward(self, spectrograms):
             if not self.training:
                 return spectrograms
@@ -90,7 +88,7 @@ def register_augmentation(
     """
 
     if not hasattr(module, "__augmentation"):
-        module.__augmentation = ModuleDict()
+        module.__augmentation = nn.ModuleDict()
         module.__augmentation_handle = dict()
 
     # unregister any augmentation that might already exist
@@ -116,12 +114,12 @@ def register_augmentation(
     module.__augmentation_handle[when] = handle
 
 
-def unregister_augmentation(module: Module, when: str = "input"):
+def unregister_augmentation(module: nn.Module, when: str = "input"):
     """Unregister augmentation
 
     Parameters
     ----------
-    module : Module
+    module : nn.Module
         Module whose augmentation should be removed.
     when : {'input', 'output'}
         Whether to remove augmentation of the input or the output.
@@ -136,6 +134,7 @@ def unregister_augmentation(module: Module, when: str = "input"):
         raise ValueError(f"Module has no registered {when} augmentation.")
 
     del module.__augmentation[when]
+
     # unregister forward hook using previously stored handle
     handle = module.__augmentation_handle.pop(when)
     handle.remove()

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -378,6 +378,8 @@ class Model(pl.LightningModule):
             self.task.setup_validation_metric()
             # this is to make sure introspection is performed here, once and for all
             _ = self.introspection
+            # Put the augmentations on the gpu if we can by registering them on the model
+            self.task._setup_augmentations()
 
         # list of layers after adding task-dependent layers
         after = set((name, id(module)) for name, module in self.named_modules())

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -245,6 +245,8 @@ class Task(pl.LightningDataModule):
         pass
 
     def _set_augmentation_sample_rate(self, augmentation: BaseWaveformTransform):
+        if augmentation is None:
+            return
         augmentation.sample_rate = self.model.hparams.sample_rate
         if isinstance(augmentation, Compose):
             for m in augmentation.transforms:

--- a/tests/augmentation_test.py
+++ b/tests/augmentation_test.py
@@ -1,11 +1,16 @@
 import pytest
+import pytorch_lightning as pl
 import torch
 from torch.nn import Module
+from torch_audiomentations import Compose, Gain
 
 from pyannote.audio.augmentation.registry import (
     register_augmentation,
     unregister_augmentation,
 )
+from pyannote.audio.models.segmentation.debug import SimpleSegmentationModel
+from pyannote.audio.tasks import VoiceActivityDetection
+from pyannote.database import FileFinder, get_protocol
 
 
 class RandomAugmentation(Module):
@@ -36,3 +41,22 @@ def test_can_unregistrer_augmentation():
 def test_fail_unregister_augmentation():
     with pytest.raises(ValueError):
         unregister_augmentation(RandomAugmentation(), when="output")
+
+
+def test_compose_augmentation_sample_rate():
+    protocol = get_protocol(
+        "Debug.SpeakerDiarization.Debug", preprocessors={"audio": FileFinder()}
+    )
+    sr = 8000
+    tfm = Gain(sample_rate=sr)
+    vad = VoiceActivityDetection(
+        protocol,
+        duration=2.0,
+        batch_size=32,
+        num_workers=4,
+        augmentation=Compose([tfm]),
+    )
+    model = SimpleSegmentationModel(task=vad)
+    trainer = pl.Trainer(fast_dev_run=True)
+    _ = trainer.fit(model)
+    assert tfm.sample_rate == model.hparams.sample_rate


### PR DESCRIPTION
There had been many changes since my last attempt #508 so I decided to start from scratch.

We realised the only way to get lightning to get the augmentations on the GPU was for them to be part of the model. That way, regardless of the multi GPU training method being used, anywhere the model is, it will have access to use the augmentations. This unfortunately does clog up the model some what but is necessary at the moment to get the augmentations working on each device. There may be another way to do this in the future.

This particular feature is hard to test with our current setup as we haven't got a good way of running tests on the GPU, perhaps this is something that we really need soon. I'd be happy to have a look into it. 

