### PR TITLE
fix: fix inference of permutation-invariant models

### DIFF
--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -355,7 +355,7 @@ class Inference:
                     / self.duration
                     * num_frames_per_chunk
                 )
-                warm_up_right = round(
+                warm_up_right = num_frames_per_chunk - round(
                     0.5
                     * (self.duration + self.warm_up[0] - self.warm_up[1] + self.step)
                     / self.duration

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -349,13 +349,13 @@ class Inference:
 
             # TODO/ documment this
             if specifications.permutation_invariant:
-                warm_up_left = round(
+                warm_up_left = math.floor(
                     0.5
                     * (self.duration + self.warm_up[0] - self.warm_up[1] - self.step)
                     / self.duration
                     * num_frames_per_chunk
                 )
-                warm_up_right = num_frames_per_chunk - round(
+                warm_up_right = num_frames_per_chunk - math.ceil(
                     0.5
                     * (self.duration + self.warm_up[0] - self.warm_up[1] + self.step)
                     / self.duration


### PR DESCRIPTION
Regular overlap-add aggregation cannot be used directly for permutation-invariant models.
Why? Because two consecutive chunks may disagree on part of their output -- leading to weird 50/50 local decisions once aggregated. 

This PR makes inference use only the (step-long) central part of each chunk in the final aggregation... essentially switching to a simple concatenation.

Segmentation on DIHARD dev before and after this change:

### Before
* False alarm = 5.9%  
* Missed detection = 6.7%
* Confusion = 27.1%

### After
* False alarm = 6.1% (+ 0.2%) 
* Missed detection = 6.8% (+ 0.1%)
* Confusion = 27.3% (+ 0.2%)

The degradation is probably not statistically significant and should be filled by carefully tuning the binarizer...
