### PR TITLE
fix: only log visual output every 10 epochs

### DIFF
--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -567,6 +567,8 @@ class SegmentationTaskMixin:
             f"{self.ACRONYM}@val_samples", fig, self.model.current_epoch
         )
 
+        plt.close(fig)
+
     @property
     def val_monitor(self):
         """Maximize validation area under ROC curve"""

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -502,7 +502,8 @@ class SegmentationTaskMixin:
             logger=True,
         )
 
-        if batch_idx > 0:
+        # log first batch visualization every 10 epochs.
+        if self.model.current_epoch % 10 > 0 or batch_idx > 0:
             return
 
         # visualize first 9 validation samples of first batch in Tensorboard

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -490,3 +490,5 @@ class Segmentation(SegmentationTaskMixin, Task):
         self.model.logger.experiment.add_figure(
             f"{self.ACRONYM}@val_samples", fig, self.model.current_epoch
         )
+
+        plt.close(fig)

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -414,7 +414,8 @@ class Segmentation(SegmentationTaskMixin, Task):
             logger=True,
         )
 
-        if batch_idx > 0:
+        # log first batch visualization every 10 epochs.
+        if self.model.current_epoch % 10 > 0 or batch_idx > 0:
             return
 
         # visualize first 9 validation samples of first batch in Tensorboard


### PR DESCRIPTION
Reasoning: remote tensorboard visualization is slow, most likely due to too many images being logged.
Solution: only log images every 10 epochs (instead of every epoch)