### PR TITLE
fix: don't replace task-dependent classifier if specifications are compatible

### DIFF
--- a/pyannote/audio/cli/pretrained.py
+++ b/pyannote/audio/cli/pretrained.py
@@ -22,12 +22,10 @@
 
 
 from typing import Text
-
 from pyannote.audio import Model
-from pyannote.audio.core.task import Task
 
 
-def pretrained(checkpoint: Text, task: Task = None):
+def pretrained(checkpoint: Text):
     return Model.from_pretrained(
-        checkpoint, task=task, map_location=lambda storage, loc: storage
+        checkpoint, map_location=lambda storage, loc: storage
     )

--- a/pyannote/audio/cli/train.py
+++ b/pyannote/audio/cli/train.py
@@ -72,13 +72,9 @@ def main(cfg: DictConfig) -> Optional[float]:
 
     # instantiate model
     pretrained = cfg.model["_target_"] == "pyannote.audio.cli.pretrained"
-    model = instantiate(cfg.model, task=task)
-
-    if not pretrained:
-        # add task-dependent layers so that later call to model.parameters()
-        # does return all layers (even task-dependent ones). this is already
-        # done for pretrained models (TODO: check that this is true)
-        model.setup(stage="fit")
+    model = instantiate(cfg.model)
+    model.task = task
+    model.setup(stage="fit")
 
     # number of batches in one epoch
     num_batches_per_epoch = model.task.train__len__() // model.task.batch_size

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -853,20 +853,4 @@ class Model(pl.LightningModule):
             model.task = task
             model.setup(stage="fit")
 
-            try:
-                missing_keys, unexpected_keys = model.load_state_dict(
-                    loaded_checkpoint["state_dict"], strict=strict
-                )
-            except RuntimeError as e:
-                if "size mismatch" in str(e):
-                    msg = (
-                        "Model has been trained for a different task. For fine tuning or transfer learning, "
-                        "it is recommended to train task-dependent layers for a few epochs "
-                        f"before training the whole model: {model.task_dependent}."
-                    )
-                    warnings.warn(msg)
-                    return model
-
-                raise e
-
         return model

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -352,7 +352,10 @@ class Model(pl.LightningModule):
         before = set((name, id(module)) for name, module in self.named_modules())
 
         # add layers that depends on task specs (e.g. final classification layer)
+        state_dict = self.state_dict()
         self.build()
+        # load pre-trained task-dependent layers if they have compatible specs
+        self.load_state_dict(state_dict, strict=False)
 
         # move layers that were added by build() to same device as the rest of the model
         for name, module in self.named_modules():

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -705,7 +705,6 @@ class Model(pl.LightningModule):
         map_location=None,
         hparams_file: Union[Path, Text] = None,
         strict: bool = True,
-        task: Task = None,
         use_auth_token: Union[Text, None] = None,
         cache_dir: Union[Path, Text] = CACHE_DIR,
         **kwargs,
@@ -733,8 +732,6 @@ class Model(pl.LightningModule):
         strict : bool, optional
             Whether to strictly enforce that the keys in checkpoint match
             the keys returned by this module’s state dict. Defaults to True.
-        task : Task, optional
-            Setup model for fine tuning (or transfer learning) on this task.
         use_auth_token : str, optional
             When loading a private huggingface.co model, set `use_auth_token`
             to True or to a string containing your hugginface.co authentication
@@ -826,15 +823,14 @@ class Model(pl.LightningModule):
                 path_for_pl,
                 map_location=map_location,
                 hparams_file=hparams_file,
-                strict=strict if task is None else False,
+                strict=strict,
                 **kwargs,
             )
         except RuntimeError as e:
             if "loss_func" in str(e):
                 msg = (
                     "Model has been trained with a task-dependent loss function. "
-                    "Either use the 'task' argument to force setting up the loss function "
-                    "or set 'strict' to False to load the model without its loss function "
+                    "Set 'strict' to False to load the model without its loss function "
                     "and prevent this warning from appearing. "
                 )
                 warnings.warn(msg)
@@ -848,9 +844,5 @@ class Model(pl.LightningModule):
                 return model
 
             raise e
-
-        if task is not None:
-            model.task = task
-            model.setup(stage="fit")
 
         return model

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -355,7 +355,18 @@ class Model(pl.LightningModule):
         state_dict = self.state_dict()
         self.build()
         # load pre-trained task-dependent layers if they have compatible specs
-        self.load_state_dict(state_dict, strict=False)
+        try:
+            self.load_state_dict(state_dict, strict=False)
+        except RuntimeError as e:
+            if "size mismatch" in str(e):
+                msg = (
+                    "Model has been trained for a different task. For fine tuning or transfer learning, "
+                    "it is recommended to train task-dependent layers for a few epochs "
+                    f"before training the whole model: {self.task_dependent}."
+                )
+                warnings.warn(msg)
+            else:
+                raise e
 
         # move layers that were added by build() to same device as the rest of the model
         for name, module in self.named_modules():

--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -351,12 +351,15 @@ class Model(pl.LightningModule):
         # list of layers before adding task-dependent layers
         before = set((name, id(module)) for name, module in self.named_modules())
 
-        # add layers that depends on task specs (e.g. final classification layer)
-        state_dict = self.state_dict()
+        # add task-dependent layers (e.g. final classification layer)
+        # and re-use original weights when compatible
+        
+        original_state_dict = self.state_dict()
         self.build()
-        # load pre-trained task-dependent layers if they have compatible specs
+        
         try:
-            self.load_state_dict(state_dict, strict=False)
+            missing_keys, unexpected_keys = self.load_state_dict(original_state_dict, strict=False)
+
         except RuntimeError as e:
             if "size mismatch" in str(e):
                 msg = (

--- a/pyannote/audio/models/segmentation/PyanNet.py
+++ b/pyannote/audio/models/segmentation/PyanNet.py
@@ -148,7 +148,14 @@ class PyanNet(Model):
                 2 if self.hparams.lstm["bidirectional"] else 1
             )
 
-        self.classifier = nn.Linear(in_features, len(self.specifications.classes))
+        num_classes = len(self.specifications.classes)
+        if (
+            not hasattr(self, "classifier")
+            or self.classifier.in_features != in_features
+            or self.classifier.out_features != num_classes
+        ):
+            self.classifier = nn.Linear(in_features, num_classes)
+
         self.activation = self.default_activation()
 
     def forward(self, waveforms: torch.Tensor) -> torch.Tensor:

--- a/pyannote/audio/models/segmentation/PyanNet.py
+++ b/pyannote/audio/models/segmentation/PyanNet.py
@@ -148,14 +148,7 @@ class PyanNet(Model):
                 2 if self.hparams.lstm["bidirectional"] else 1
             )
 
-        num_classes = len(self.specifications.classes)
-        if (
-            not hasattr(self, "classifier")
-            or self.classifier.in_features != in_features
-            or self.classifier.out_features != num_classes
-        ):
-            self.classifier = nn.Linear(in_features, num_classes)
-
+        self.classifier = nn.Linear(in_features, len(self.specifications.classes))
         self.activation = self.default_activation()
 
     def forward(self, waveforms: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
When fine-tuning `PyanNet` for a different task, the classification module is always replaced. However, if the task remains the same or the specifications are compatible (feature dimensionality and number of classes) it might be better to keep the pre-trained module instead of replacing it with a randomly initialized one.