### PR TITLE
Fix Audio.validate_file not raising error in one case

### DIFF
--- a/pyannote/audio/core/io.py
+++ b/pyannote/audio/core/io.py
@@ -161,6 +161,12 @@ class Audio:
                 raise ValueError(f"File {path} does not exist")
 
             file.setdefault("uri", path.stem)
+        
+        else:
+
+            raise ValueError(
+                "Neither 'waveform' nor 'audio' is available for this file."
+            )
 
         return file
 


### PR DESCRIPTION
The `Audio.validate_file` method returned without raising a ValueError even when both the `audio` and `waveform` attributes of the file weren't defined.