### PR TITLE
Make Task metric(s) specifiable

### DIFF
--- a/pyannote/audio/core/model.py
+++ b/pyannote/audio/core/model.py
@@ -34,6 +34,7 @@ import torch
 import torch.nn as nn
 import torch.optim
 from huggingface_hub import cached_download, hf_hub_url
+from pyannote.core import SlidingWindow
 from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.model_summary import ModelSummary
 from semver import VersionInfo
@@ -42,7 +43,6 @@ from torch.utils.data import DataLoader
 from pyannote.audio import __version__
 from pyannote.audio.core.io import Audio
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
-from pyannote.core import SlidingWindow
 
 CACHE_DIR = os.getenv(
     "PYANNOTE_CACHE",
@@ -385,7 +385,7 @@ class Model(pl.LightningModule):
             # setup custom loss function
             self.task.setup_loss_func()
             # setup custom validation metrics
-            validation_metric = self.task.setup_validation_metric()
+            validation_metric = self.task.metric
             if validation_metric is not None:
                 self.validation_metric = validation_metric
                 self.validation_metric.to(self.device)

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -29,7 +29,7 @@ import warnings
 from dataclasses import dataclass
 from enum import Enum
 from numbers import Number
-from typing import Dict, List, Optional, Sequence, Text, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Text, Tuple, Type, Union
 
 import pytorch_lightning as pl
 import torch
@@ -248,11 +248,33 @@ class Task(pl.LightningDataModule):
     def setup_loss_func(self):
         pass
 
-    def setup_validation_metric(self) -> Metric:
-        if self.metrics is None:
-            self.metrics = self.get_default_validation_metric()
+    def get_val_metric_prefix(self) -> str:
+        return f"{self.ACRONYM}@val_"
 
-        return MetricCollection(self.metrics, prefix=f"{self.ACRONYM}@val_")
+    def get_default_val_metric_name(self, metric: Union[Metric, Type]) -> str:
+        prefix = self.get_val_metric_prefix()
+        mn = Task.get_metric_name(metric)
+        return f"{prefix}{mn}"
+
+    @staticmethod
+    def get_metric_name(metric: Union[Metric, Type]) -> str:
+        if isinstance(metric, Metric):
+            return type(metric).__name__.lower()
+        elif isinstance(metric, Type):
+            return metric.__name__.lower()
+        else:
+            msg = "get_metric_name only accepts Metric and Type arguments."
+            raise ValueError(msg)
+
+    def setup_validation_metric(self) -> Metric:
+        metricsarg = self.metrics
+        if self.metrics is None:
+            metricsarg = self.get_default_validation_metric()
+
+        # If the metrics' names are not given, generate automatically lowercase ones
+        if not isinstance(metricsarg, dict):
+            metricsarg = {Task.get_metric_name(m): m for m in self.metrics}
+        return MetricCollection(metricsarg, prefix=self.get_val_metric_prefix())
 
     def train__iter__(self):
         # will become train_dataset.__iter__ method

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -278,8 +278,9 @@ class Task(pl.LightningDataModule):
         prefix = f"{self.__class__.__name__}-"
         if hasattr(self.protocol, "name"):
             # "." has a special meaning for pytorch-lightning checkpointing
-            # so we replace any encountered "." by "_" in protocol names
-            prefix += f"{self.protocol.name.replace('.', '_')}-"
+            # so we remove dots from protocol names
+            name_without_dots = "".join(self.protocol.name.split("."))
+            prefix += f"{name_without_dots}-"
 
         return prefix
 
@@ -372,7 +373,7 @@ class Task(pl.LightningDataModule):
         # compute loss
         loss = self.default_loss(self.specifications, y, y_pred, weight=weight)
         self.model.log(
-            f"{self.logging_prefix}{stage}-loss",
+            f"{self.logging_prefix}{stage.capitalize()}Loss",
             loss,
             on_step=False,
             on_epoch=True,

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -215,7 +215,7 @@ class Task(pl.LightningDataModule):
         Returns
         -------
         Union[Metric, Sequence[Metric], Dict[str, Metric]]
-            The default validation metric(s) of this task (follow torchmetrics MetricCollection convention)
+            The default validation metric(s) of this task (something that can be plugged in a torchmetrics.MetricCollection).
         """
         pass
 

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -207,7 +207,8 @@ class Task(pl.LightningDataModule):
         self.augmentation = augmentation
         self.metrics = metrics
 
-    def get_default_validation_metric(
+    @property
+    def default_validation_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         """Used to get validation metrics when none is provided by the user
@@ -248,11 +249,12 @@ class Task(pl.LightningDataModule):
     def setup_loss_func(self):
         pass
 
-    def get_val_metric_prefix(self) -> str:
+    @property
+    def val_metric_prefix(self) -> str:
         return f"{self.ACRONYM}@val_"
 
     def get_default_val_metric_name(self, metric: Union[Metric, Type]) -> str:
-        prefix = self.get_val_metric_prefix()
+        prefix = self.get_val_metric_prefix
         mn = Task.get_metric_name(metric)
         return f"{prefix}{mn}"
 
@@ -269,7 +271,7 @@ class Task(pl.LightningDataModule):
     def setup_validation_metric(self) -> Metric:
         metricsarg = self.metrics
         if self.metrics is None:
-            metricsarg = self.get_default_validation_metric()
+            metricsarg = self.default_validation_metric
 
         # Convert metricargs to a list, if it is a single Metric
         if isinstance(metricsarg, Metric):
@@ -278,7 +280,7 @@ class Task(pl.LightningDataModule):
         # If the metrics' names are not given, generate them automatically
         if not isinstance(metricsarg, dict):
             metricsarg = {Task.get_metric_name(m): m for m in metricsarg}
-        return MetricCollection(metricsarg, prefix=self.get_val_metric_prefix())
+        return MetricCollection(metricsarg, prefix=self.val_metric_prefix)
 
     def train__iter__(self):
         # will become train_dataset.__iter__ method

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -271,7 +271,9 @@ class Task(pl.LightningDataModule):
         if self.metrics is None:
             metricsarg = self.get_default_validation_metric()
 
-        # If the metrics' names are not given, generate automatically lowercase ones
+        if isinstance(metricsarg, Metric):
+            metricsarg = [metricsarg]
+        # If the metrics' names are not given, generate them automatically
         if not isinstance(metricsarg, dict):
             metricsarg = {Task.get_metric_name(m): m for m in self.metrics}
         return MetricCollection(metricsarg, prefix=self.get_val_metric_prefix())

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -271,11 +271,13 @@ class Task(pl.LightningDataModule):
         if self.metrics is None:
             metricsarg = self.get_default_validation_metric()
 
+        # Convert metricargs to a list, if it is a single Metric
         if isinstance(metricsarg, Metric):
             metricsarg = [metricsarg]
+        # Convert metricsarg to a dict, now that it is a list
         # If the metrics' names are not given, generate them automatically
         if not isinstance(metricsarg, dict):
-            metricsarg = {Task.get_metric_name(m): m for m in self.metrics}
+            metricsarg = {Task.get_metric_name(m): m for m in metricsarg}
         return MetricCollection(metricsarg, prefix=self.get_val_metric_prefix())
 
     def train__iter__(self):

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -33,6 +33,7 @@ from typing import Dict, List, Optional, Sequence, Text, Tuple, Type, Union
 
 import pytorch_lightning as pl
 import torch
+from pyannote.database import Protocol
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 from torch.utils.data._utils.collate import default_collate
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
@@ -41,7 +42,6 @@ from typing_extensions import Literal
 
 from pyannote.audio.utils.loss import binary_cross_entropy, nll_loss
 from pyannote.audio.utils.protocol import check_protocol
-from pyannote.database import Protocol
 
 
 # Type of machine learning problem
@@ -254,7 +254,7 @@ class Task(pl.LightningDataModule):
         return f"{self.ACRONYM}@val_"
 
     def get_default_val_metric_name(self, metric: Union[Metric, Type]) -> str:
-        prefix = self.get_val_metric_prefix
+        prefix = self.val_metric_prefix
         mn = Task.get_metric_name(metric)
         return f"{prefix}{mn}"
 

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,13 +23,18 @@
 
 from __future__ import annotations
 
+try:
+    from functools import cached_property
+except ImportError:
+    from backports.cached_property import cached_property
+
 import multiprocessing
 import sys
 import warnings
 from dataclasses import dataclass
 from enum import Enum
 from numbers import Number
-from typing import Dict, List, Optional, Sequence, Text, Tuple, Type, Union
+from typing import Dict, List, Optional, Sequence, Text, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
@@ -152,6 +157,9 @@ class Task(pl.LightningDataModule):
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to value returned by `default_metric` method.
 
     Attributes
     ----------
@@ -169,7 +177,7 @@ class Task(pl.LightningDataModule):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
         super().__init__()
 
@@ -205,20 +213,7 @@ class Task(pl.LightningDataModule):
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.augmentation = augmentation
-        self.metrics = metrics
-
-    @property
-    def default_validation_metric(
-        self,
-    ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
-        """Used to get validation metrics when none is provided by the user
-
-        Returns
-        -------
-        Union[Metric, Sequence[Metric], Dict[str, Metric]]
-            The default validation metric(s) of this task (something that can be plugged in a torchmetrics.MetricCollection).
-        """
-        pass
+        self._metric = metric
 
     def prepare_data(self):
         """Use this to download and prepare data
@@ -248,39 +243,6 @@ class Task(pl.LightningDataModule):
 
     def setup_loss_func(self):
         pass
-
-    @property
-    def val_metric_prefix(self) -> str:
-        return f"{self.ACRONYM}@val_"
-
-    def get_default_val_metric_name(self, metric: Union[Metric, Type]) -> str:
-        prefix = self.val_metric_prefix
-        mn = Task.get_metric_name(metric)
-        return f"{prefix}{mn}"
-
-    @staticmethod
-    def get_metric_name(metric: Union[Metric, Type]) -> str:
-        if isinstance(metric, Metric):
-            return type(metric).__name__.lower()
-        elif isinstance(metric, Type):
-            return metric.__name__.lower()
-        else:
-            msg = "get_metric_name only accepts Metric and Type arguments."
-            raise ValueError(msg)
-
-    def setup_validation_metric(self) -> Metric:
-        metricsarg = self.metrics
-        if self.metrics is None:
-            metricsarg = self.default_validation_metric
-
-        # Convert metricargs to a list, if it is a single Metric
-        if isinstance(metricsarg, Metric):
-            metricsarg = [metricsarg]
-        # Convert metricsarg to a dict, now that it is a list
-        # If the metrics' names are not given, generate them automatically
-        if not isinstance(metricsarg, dict):
-            metricsarg = {Task.get_metric_name(m): m for m in metricsarg}
-        return MetricCollection(metricsarg, prefix=self.val_metric_prefix)
 
     def train__iter__(self):
         # will become train_dataset.__iter__ method
@@ -443,6 +405,24 @@ class Task(pl.LightningDataModule):
     def validation_epoch_end(self, outputs):
         pass
 
+    def default_metric(self) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
+        """Default validation metric"""
+        msg = f"Missing '{self.__class__.__name__}.default_metric' method."
+        raise NotImplementedError(msg)
+
+    @cached_property
+    def metric(self) -> MetricCollection:
+        if self._metric is None:
+            self._metric = self.default_metric()
+
+        prefix = f"{self.__class__.__name__}-"
+        if hasattr(self.protocol, "name"):
+            # "." has a special meaning for pytorch-lightning checkpointing
+            # so we replace any encountered "." by "_" in protocol names
+            prefix += f"{self.protocol.name.replace('.', '_')}-"
+
+        return MetricCollection(self._metric, prefix=prefix)
+
     @property
     def val_monitor(self):
         """Quantity (and direction) to monitor
@@ -461,7 +441,6 @@ class Task(pl.LightningDataModule):
         pytorch_lightning.callbacks.ModelCheckpoint
         pytorch_lightning.callbacks.EarlyStopping
         """
-        if self.has_validation:
-            return f"{self.ACRONYM}@val_loss", "min"
-        else:
-            return None, "min"
+
+        name, metric = next(iter(self.metric.items()))
+        return name, "max" if metric.higher_is_better else "min"

--- a/pyannote/audio/tasks/embedding/arcface.py
+++ b/pyannote/audio/tasks/embedding/arcface.py
@@ -23,8 +23,11 @@
 
 from __future__ import annotations
 
+from typing import Dict, Sequence, Union
+
 import pytorch_metric_learning.losses
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+from torchmetrics import Metric
 
 from pyannote.audio.core.task import Task
 from pyannote.database import Protocol
@@ -87,6 +90,7 @@ class SupervisedRepresentationLearningWithArcFace(
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
+        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         self.num_chunks_per_class = num_chunks_per_class
@@ -103,6 +107,7 @@ class SupervisedRepresentationLearningWithArcFace(
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
+            metrics=metrics,
         )
 
     def setup_loss_func(self):

--- a/pyannote/audio/tasks/embedding/arcface.py
+++ b/pyannote/audio/tasks/embedding/arcface.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,11 +26,11 @@ from __future__ import annotations
 from typing import Dict, Sequence, Union
 
 import pytorch_metric_learning.losses
+from pyannote.database import Protocol
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 from torchmetrics import Metric
 
 from pyannote.audio.core.task import Task
-from pyannote.database import Protocol
 
 from .mixins import SupervisedRepresentationLearningTaskMixin
 
@@ -70,6 +70,9 @@ class SupervisedRepresentationLearningWithArcFace(
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to AUROC (area under the ROC curve).
     """
 
     ACRONYM = "arcface"
@@ -90,7 +93,7 @@ class SupervisedRepresentationLearningWithArcFace(
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         self.num_chunks_per_class = num_chunks_per_class
@@ -107,7 +110,7 @@ class SupervisedRepresentationLearningWithArcFace(
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
-            metrics=metrics,
+            metric=metric,
         )
 
     def setup_loss_func(self):

--- a/pyannote/audio/tasks/embedding/arcface.py
+++ b/pyannote/audio/tasks/embedding/arcface.py
@@ -75,8 +75,6 @@ class SupervisedRepresentationLearningWithArcFace(
         Defaults to AUROC (area under the ROC curve).
     """
 
-    ACRONYM = "arcface"
-
     #  TODO: add a ".metric" property that tells how speaker embedding trained with this approach
     #  should be compared. could be a string like "cosine" or "euclidean" or a pdist/cdist-like
     #  callable. this ".metric" property should be propagated all the way to Inference (via the model).

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -28,7 +28,7 @@ import torch.nn.functional as F
 from torchmetrics import AUROC, Metric
 from tqdm import tqdm
 
-from pyannote.audio.core.task import Problem, Resolution, Specifications
+from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.utils.random import create_rng_for_worker
 from pyannote.core import Segment
 from pyannote.database.protocol import (
@@ -293,10 +293,10 @@ class SupervisedRepresentationLearningTaskMixin:
     @property
     def val_monitor(self):
 
-        if self.has_validation:
+        if self.has_validation and self.metrics is None:
 
             if isinstance(self.protocol, SpeakerVerificationProtocol):
-                return f"{self.ACRONYM}@val_auroc", "max"
+                return Task.get_default_val_metric_name(AUROC), "max"
 
             elif isinstance(self.protocol, SpeakerDiarizationProtocol):
                 return None, "min"

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +25,16 @@ from typing import Dict, Optional, Sequence, Union
 
 import torch
 import torch.nn.functional as F
-from torchmetrics import AUROC, Metric
-from tqdm import tqdm
-
-from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
-from pyannote.audio.utils.random import create_rng_for_worker
 from pyannote.core import Segment
 from pyannote.database.protocol import (
     SpeakerDiarizationProtocol,
     SpeakerVerificationProtocol,
 )
+from torchmetrics import AUROC, Metric
+from tqdm import tqdm
+
+from pyannote.audio.core.task import Problem, Resolution, Specifications
+from pyannote.audio.utils.random import create_rng_for_worker
 
 
 class SupervisedRepresentationLearningTaskMixin:
@@ -124,8 +124,7 @@ class SupervisedRepresentationLearningTaskMixin:
         if isinstance(self.protocol, SpeakerVerificationProtocol):
             self._validation = list(self.protocol.development_trial())
 
-    @property
-    def default_validation_metric(
+    def default_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         return AUROC(compute_on_step=False)
@@ -290,17 +289,3 @@ class SupervisedRepresentationLearningTaskMixin:
 
         elif isinstance(self.protocol, SpeakerDiarizationProtocol):
             pass
-
-    @property
-    def val_monitor(self):
-
-        if self.has_validation and self.metrics is None:
-
-            if isinstance(self.protocol, SpeakerVerificationProtocol):
-                return Task.get_default_val_metric_name(AUROC), "max"
-
-            elif isinstance(self.protocol, SpeakerDiarizationProtocol):
-                return None, "min"
-
-        else:
-            return None, "min"

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -221,7 +221,7 @@ class SupervisedRepresentationLearningTaskMixin:
         loss = self.model.loss_func(self.model(X), y)
 
         self.model.log(
-            f"{self.logging_prefix}train-loss",
+            f"{self.logging_prefix}TrainLoss",
             loss,
             on_step=False,
             on_epoch=True,

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -221,7 +221,7 @@ class SupervisedRepresentationLearningTaskMixin:
         loss = self.model.loss_func(self.model(X), y)
 
         self.model.log(
-            f"{self.ACRONYM}@train_loss",
+            f"{self.logging_prefix}train-loss",
             loss,
             on_step=False,
             on_epoch=True,

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -124,7 +124,8 @@ class SupervisedRepresentationLearningTaskMixin:
         if isinstance(self.protocol, SpeakerVerificationProtocol):
             self._validation = list(self.protocol.development_trial())
 
-    def get_default_validation_metric(
+    @property
+    def default_validation_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         return AUROC(compute_on_step=False)

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 import math
-from typing import Optional
+from typing import Dict, Optional, Sequence, Union
 
 import torch
 import torch.nn.functional as F
-from torchmetrics import AUROC
+from torchmetrics import AUROC, Metric
 from tqdm import tqdm
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications
@@ -124,7 +124,9 @@ class SupervisedRepresentationLearningTaskMixin:
         if isinstance(self.protocol, SpeakerVerificationProtocol):
             self._validation = list(self.protocol.development_trial())
 
-    def setup_validation_metric(self):
+    def get_default_validation_metric(
+        self,
+    ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         return AUROC(compute_on_step=False)
 
     def train__iter__(self):
@@ -277,8 +279,7 @@ class SupervisedRepresentationLearningTaskMixin:
             y_true = batch["y"]
             self.model.validation_metric(y_pred, y_true)
 
-            self.model.log(
-                f"{self.ACRONYM}@val_auroc",
+            self.model.log_dict(
                 self.model.validation_metric,
                 on_step=False,
                 on_epoch=True,

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -585,7 +585,7 @@ class SegmentationTaskMixin:
         plt.tight_layout()
 
         self.model.logger.experiment.add_figure(
-            f"{self.ACRONYM}@val_samples", fig, self.model.current_epoch
+            f"{self.logging_prefix}val-samples", fig, self.model.current_epoch
         )
 
         plt.close(fig)

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -466,6 +466,7 @@ class SegmentationTaskMixin:
         # y_pred = (batch_size, num_frames, num_classes)
 
         # postprocess
+        # TODO: remove this because metrics should take care of postprocessing
         y_pred = self.validation_postprocess(y, y_pred)
 
         # - remove warm-up frames

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -585,7 +585,7 @@ class SegmentationTaskMixin:
         plt.tight_layout()
 
         self.model.logger.experiment.add_figure(
-            f"{self.logging_prefix}val-samples", fig, self.model.current_epoch
+            f"{self.logging_prefix}ValSamples", fig, self.model.current_epoch
         )
 
         plt.close(fig)

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -23,11 +23,11 @@
 import math
 import random
 import warnings
-from typing import List, Optional, Text, Tuple
+from typing import Dict, List, Optional, Sequence, Text, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-from torchmetrics import AUROC
+from torchmetrics import AUROC, Metric
 from typing_extensions import Literal
 
 from pyannote.audio.core.io import Audio, AudioFile
@@ -120,7 +120,9 @@ class SegmentationTaskMixin:
 
         random.shuffle(self._validation)
 
-    def setup_validation_metric(self):
+    def get_default_validation_metric(
+        self,
+    ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         """Setup default validation metric
 
         Use macro-average of area under the ROC curve
@@ -518,8 +520,7 @@ class SegmentationTaskMixin:
             # TODO: implement when pyannote.audio gets its first mono-label segmentation task
             raise NotImplementedError()
 
-        self.model.log(
-            f"{self.ACRONYM}@val_auroc",
+        self.model.log_dict(
             self.model.validation_metric,
             on_step=False,
             on_epoch=True,

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -615,5 +615,7 @@ class SegmentationTaskMixin:
 
     @property
     def val_monitor(self):
-        """Maximize validation area under ROC curve"""
-        return f"{self.ACRONYM}@val_auroc", "max"
+        if self.has_validation and self.metrics is None:
+            return self.get_default_val_metric_name(AUROC), "max"
+        else:
+            return None, "min"

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -489,6 +489,8 @@ class SegmentationTaskMixin:
         # torchmetrics to be happy... more details can be found here:
         # https://torchmetrics.readthedocs.io/en/latest/references/modules.html#input-types
 
+        batch_size, num_frames2, num_classes = preds.shape
+
         if self.specifications.problem == Problem.BINARY_CLASSIFICATION:
             # target: shape (batch_size, num_frames), type binary
             # preds:  shape (batch_size, num_frames, 1), type float
@@ -497,7 +499,13 @@ class SegmentationTaskMixin:
             # target: shape (N,), type binary
             # preds:  shape (N,), type float
 
-            self.model.validation_metric(preds.reshape(-1), target.reshape(-1))
+            self.model.validation_metric(
+                preds.reshape(-1),
+                target.reshape(-1),
+                batch_size=batch_size,
+                num_frames=num_frames2,
+                num_classes=num_classes,
+            )
 
         elif self.specifications.problem == Problem.MULTI_LABEL_CLASSIFICATION:
             # target: shape (batch_size, num_frames, num_classes), type binary
@@ -507,7 +515,13 @@ class SegmentationTaskMixin:
             # target: shape (N, ), type binary
             # preds:  shape (N, ), type float
 
-            self.model.validation_metric(preds.reshape(-1), target.reshape(-1))
+            self.model.validation_metric(
+                preds.reshape(-1),
+                target.reshape(-1),
+                batch_size=batch_size,
+                num_frames=num_frames2,
+                num_classes=num_classes,
+            )
 
         elif self.specifications.problem == Problem.MONO_LABEL_CLASSIFICATION:
             # target: shape (batch_size, num_frames, num_classes), type binary

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -121,7 +121,8 @@ class SegmentationTaskMixin:
 
         random.shuffle(self._validation)
 
-    def get_default_validation_metric(
+    @property
+    def default_validation_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
         """Setup default validation metric

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -89,8 +89,6 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         Defaults to AUROC (area under the ROC curve).
     """
 
-    ACRONYM = "osd"
-
     OVERLAP_DEFAULTS = {"probability": 0.5, "snr_min": 0.0, "snr_max": 10.0}
 
     def __init__(

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 
-from typing import Text, Tuple, Union
+from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -101,6 +102,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
+        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -111,6 +113,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
+            metrics=metrics,
         )
 
         self.specifications = Specifications(

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,12 @@
 from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
+from pyannote.database import Protocol
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
-from pyannote.database import Protocol
 
 
 class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
@@ -84,6 +84,9 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to AUROC (area under the ROC curve).
     """
 
     ACRONYM = "osd"
@@ -102,7 +105,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -113,7 +116,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
-            metrics=metrics,
+            metric=metric,
         )
 
         self.specifications = Specifications(

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -102,8 +102,6 @@ class Segmentation(SegmentationTaskMixin, Task):
     Proc. Interspeech 2021
     """
 
-    ACRONYM = "seg"
-
     OVERLAP_DEFAULTS = {"probability": 0.5, "snr_min": 0.0, "snr_max": 10.0}
 
     def __init__(
@@ -353,7 +351,7 @@ class Segmentation(SegmentationTaskMixin, Task):
         seg_loss = self.segmentation_loss(permutated_prediction, target, weight=weight)
 
         self.model.log(
-            f"{self.ACRONYM}@train_seg_loss",
+            f"{self.logging_prefix}train-loss-seg",
             seg_loss,
             on_step=False,
             on_epoch=True,
@@ -370,7 +368,7 @@ class Segmentation(SegmentationTaskMixin, Task):
             )
 
             self.model.log(
-                f"{self.ACRONYM}@train_vad_loss",
+                f"{self.logging_prefix}train-loss-vad",
                 vad_loss,
                 on_step=False,
                 on_epoch=True,
@@ -381,13 +379,14 @@ class Segmentation(SegmentationTaskMixin, Task):
         loss = seg_loss + vad_loss
 
         self.model.log(
-            f"{self.ACRONYM}@train_loss",
+            f"{self.logging_prefix}train-loss",
             loss,
             on_step=False,
             on_epoch=True,
             prog_bar=True,
             logger=True,
         )
+
         return {"loss": loss}
 
     def default_metric(

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -33,6 +33,12 @@ from typing_extensions import Literal
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
+from pyannote.audio.torchmetrics import (
+    DiarizationErrorRate,
+    FalseAlarmRate,
+    MissedDetectionRate,
+    SpeakerConfusionRate,
+)
 from pyannote.audio.utils.loss import binary_cross_entropy, mse_loss
 from pyannote.audio.utils.permutation import permutate
 
@@ -384,9 +390,16 @@ class Segmentation(SegmentationTaskMixin, Task):
         )
         return {"loss": loss}
 
-    def validation_postprocess(self, y, y_pred):
-        permutated_y_pred, _ = permutate(y, y_pred)
-        return permutated_y_pred
+    def default_metric(
+        self,
+    ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
+        """Returns diarization error rate and its components"""
+        return [
+            DiarizationErrorRate(),
+            SpeakerConfusionRate(),
+            MissedDetectionRate(),
+            FalseAlarmRate(),
+        ]
 
 
 def main(protocol: str, subset: str = "test", model: str = "pyannote/segmentation"):

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -351,7 +351,7 @@ class Segmentation(SegmentationTaskMixin, Task):
         seg_loss = self.segmentation_loss(permutated_prediction, target, weight=weight)
 
         self.model.log(
-            f"{self.logging_prefix}train-loss-seg",
+            f"{self.logging_prefix}TrainSegLoss",
             seg_loss,
             on_step=False,
             on_epoch=True,
@@ -368,7 +368,7 @@ class Segmentation(SegmentationTaskMixin, Task):
             )
 
             self.model.log(
-                f"{self.logging_prefix}train-loss-vad",
+                f"{self.logging_prefix}TrainVADLoss",
                 vad_loss,
                 on_step=False,
                 on_epoch=True,
@@ -379,7 +379,7 @@ class Segmentation(SegmentationTaskMixin, Task):
         loss = seg_loss + vad_loss
 
         self.model.log(
-            f"{self.logging_prefix}train-loss",
+            f"{self.logging_prefix}TrainLoss",
             loss,
             on_step=False,
             on_epoch=True,

--- a/pyannote/audio/tasks/segmentation/speaker_change_detection.py
+++ b/pyannote/audio/tasks/segmentation/speaker_change_detection.py
@@ -82,8 +82,6 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
         Defaults to AUROC (area under the ROC curve).
     """
 
-    ACRONYM = "scd"
-
     def __init__(
         self,
         protocol: Protocol,

--- a/pyannote/audio/tasks/segmentation/speaker_change_detection.py
+++ b/pyannote/audio/tasks/segmentation/speaker_change_detection.py
@@ -20,11 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Text, Tuple, Union
+from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
 import scipy.signal
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -92,6 +93,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
+        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -102,6 +104,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
+            metrics=metrics,
         )
 
         self.balance = balance

--- a/pyannote/audio/tasks/segmentation/speaker_change_detection.py
+++ b/pyannote/audio/tasks/segmentation/speaker_change_detection.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,12 @@ from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
 import scipy.signal
+from pyannote.database import Protocol
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
-from pyannote.database import Protocol
 
 
 class SpeakerChangeDetection(SegmentationTaskMixin, Task):
@@ -77,6 +77,9 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to AUROC (area under the ROC curve).
     """
 
     ACRONYM = "scd"
@@ -93,7 +96,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -104,7 +107,7 @@ class SpeakerChangeDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
-            metrics=metrics,
+            metric=metric,
         )
 
         self.balance = balance

--- a/pyannote/audio/tasks/segmentation/speaker_tracking.py
+++ b/pyannote/audio/tasks/segmentation/speaker_tracking.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,12 @@
 from typing import Dict, List, Optional, Sequence, Text, Tuple, Union
 
 import numpy as np
+from pyannote.database import Protocol
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
-from pyannote.database import Protocol
 
 
 class SpeakerTracking(SegmentationTaskMixin, Task):
@@ -71,6 +71,9 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to AUROC (area under the ROC curve).
     """
 
     ACRONYM = "spk"
@@ -86,7 +89,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -97,7 +100,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
-            metrics=metrics,
+            metric=metric,
         )
 
         self.balance = balance

--- a/pyannote/audio/tasks/segmentation/speaker_tracking.py
+++ b/pyannote/audio/tasks/segmentation/speaker_tracking.py
@@ -76,8 +76,6 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
         Defaults to AUROC (area under the ROC curve).
     """
 
-    ACRONYM = "spk"
-
     def __init__(
         self,
         protocol: Protocol,

--- a/pyannote/audio/tasks/segmentation/speaker_tracking.py
+++ b/pyannote/audio/tasks/segmentation/speaker_tracking.py
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Optional, Text, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Text, Tuple, Union
 
 import numpy as np
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -85,6 +86,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
+        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -95,6 +97,7 @@ class SpeakerTracking(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
+            metrics=metrics,
         )
 
         self.balance = balance

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -75,8 +75,6 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         Defaults to AUROC (area under the ROC curve).
     """
 
-    ACRONYM = "vad"
-
     def __init__(
         self,
         protocol: Protocol,

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Text, Tuple, Union
+from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
+from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
@@ -84,6 +85,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
+        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -94,6 +96,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
+            metrics=metrics,
         )
 
         self.balance = balance

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 CNRS
+# Copyright (c) 2020- CNRS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,12 @@
 from typing import Dict, Sequence, Text, Tuple, Union
 
 import numpy as np
+from pyannote.database import Protocol
 from torch_audiomentations.core.transforms_interface import BaseWaveformTransform
 from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications, Task
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTaskMixin
-from pyannote.database import Protocol
 
 
 class VoiceActivityDetection(SegmentationTaskMixin, Task):
@@ -70,6 +70,9 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
     augmentation : BaseWaveformTransform, optional
         torch_audiomentations waveform transform, used by dataloader
         during training.
+    metric : optional
+        Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
+        Defaults to AUROC (area under the ROC curve).
     """
 
     ACRONYM = "vad"
@@ -85,7 +88,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         num_workers: int = None,
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
-        metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
     ):
 
         super().__init__(
@@ -96,7 +99,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
             num_workers=num_workers,
             pin_memory=pin_memory,
             augmentation=augmentation,
-            metrics=metrics,
+            metric=metric,
         )
 
         self.balance = balance

--- a/tutorials/add_your_own_task.ipynb
+++ b/tutorials/add_your_own_task.ipynb
@@ -153,8 +153,6 @@
     "class SoundEventDetection(Task):\n",
     "    \"\"\"Sound event detection\"\"\"\n",
     "\n",
-    "    ACRONYM = \"sed\"\n",
-    "\n",
     "    def __init__(\n",
     "        self,\n",
     "        protocol: Protocol,\n",


### PR DESCRIPTION
It is currently impossible to change the validation metric used by a task without creating a child class and overriding the relevant methods.

This PR adds a `metrics` parameter in the constructor which allows anything a torchmetrics.MetricCollection can allow (individual metric, list of metric, dictionary of metrics).
The model.log_dict(...) method is used instead of the model.log(...) one because the Tasks now always work with a MetricCollection instead of a Metric.
Child class of methods may still define a default metric through overriding `get_default_validation_metric`.
And "new" default metrics, although they are now contained in a MetricCollection, are still logged in the exact same fashion with the same naming.

Users that have set the metrics parameter are expected to retrieve the real metric name (if they haven't set it by passing a dictionary) by using the `task.get_default_val_metric_name(my_metric)` method (for example if they want to use it with a Checkpoint callback).


I think (at least) one implementation question remains:

**Should it be possible to parametrize what `task.val_monitor()` returns?** (or in general, specify a "default" metric)
Knowing that to have a default metric, we need both to have the metric and if we want to maximize or minimize it. 

The current behaviour is to use `val_loss` for the base Task class (unchanged). As for Mixins of Task, task.val_monitor() returns a value only if the default metric is used (and a `None, "min"` tuple when a user `metrics` is given).
Possibles solutions i see:
   - Keep things as they are now (maybe raise an error) and expect the user not to rely on val_monitor() when they pass their own metrics
   - Add another optional constructor parameter `val_monitor` that takes a `Tuple[Metric, str]` and which will be used to return a value in .val_monitor()