### PR TITLE
Relax model name of SpeechBrain embedding

### DIFF
--- a/pyannote/audio/pipelines/speaker_verification.py
+++ b/pyannote/audio/pipelines/speaker_verification.py
@@ -265,7 +265,7 @@ def PretrainedSpeakerEmbedding(embedding: PipelineModel, device: torch.device = 
     >>> embeddings = get_embedding(waveforms, masks=masks)
     """
 
-    if isinstance(embedding, str) and embedding.split("/")[0] == "speechbrain":
+    if isinstance(embedding, str) and "speechbrain" in embedding:
         return SpeechBrainPretrainedSpeakerEmbedding(embedding, device=device)
     else:
         return PyannoteAudioPretrainedSpeakerEmbedding(embedding, device=device)


### PR DESCRIPTION
In order to use an own trained SpeechBrain model, the top directory of SpeechBrain model must be named "speechbrain".
With this change, the use of SpeechBrain will be determined by whether the model name contains "speechbrain" or not.

Related discussion.
https://github.com/pyannote/pyannote-audio/discussions/920