### PR TITLE
Fix torchmetrics DER threshold being on a different device when using cuda

### DIFF
--- a/pyannote/audio/torchmetrics/functional/audio/diarization_error_rate.py
+++ b/pyannote/audio/torchmetrics/functional/audio/diarization_error_rate.py
@@ -57,7 +57,7 @@ def _der_update(
     # make threshold a (num_thresholds,) tensor
     scalar_threshold = isinstance(threshold, Number)
     if scalar_threshold:
-        threshold = torch.tensor([threshold], dtype=preds.dtype)
+        threshold = torch.tensor([threshold], dtype=preds.dtype, device=preds.device)
 
     # find the optimal mapping between target and (soft) predictions
     permutated_preds, _ = permutate(


### PR DESCRIPTION
In the torchmetrics, when using a scalar threshold, the threshold is initialized with
`threshold = torch.tensor([threshold], dtype=preds.dtype)`
and later used in
`hypothesis = (permutated_preds.unsqueeze(-1) > threshold).float()`

When the preds tensor passed is on a cuda device, this could result in a runtime error :
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

This PR simply changes threshold declaration to
`threshold = torch.tensor([threshold], dtype=preds.dtype, device=preds.device)`