### PR TITLE
Recommend PyTorch 1.11 for SpeechBrain compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Only Python 3.8+ is officially supported (though it might work with Python 3.7)
 conda create -n pyannote python=3.8
 conda activate pyannote
 # Pytorch 1.11 is required for speechbrain compatibility. See https://pytorch.org/get-started/previous-versions/#v1110
-conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 -c pytorch
 pip install https://github.com/pyannote/pyannote-audio/archive/develop.zip
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Only Python 3.8+ is officially supported (though it might work with Python 3.7)
 ```bash
 conda create -n pyannote python=3.8
 conda activate pyannote
-conda install pytorch torchaudio -c pytorch
+# Pytorch 1.11 is required for speechbrain compatibility. See https://pytorch.org/get-started/previous-versions/#v1110
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
 pip install https://github.com/pyannote/pyannote-audio/archive/develop.zip
 ```
 


### PR DESCRIPTION
The latest version of PyTorch (1.12) is incompatible with SpeechBrain (used for diarization pipeline)

Update README to recommend installing PyTorch 1.11 with conda
https://pytorch.org/get-started/previous-versions/#v1110

Fixes this issue: https://github.com/pyannote/pyannote-audio/issues/855