### PR TITLE
restart kernel after env set

### DIFF
--- a/tutorials/training_a_model.ipynb
+++ b/tutorials/training_a_model.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "This tutorial assumes that \n",
     "* the [AMI corpus](https://groups.inf.ed.ac.uk/ami/corpus/) has already been [setup for use with `pyannote`](https://github.com/pyannote/AMI-diarization-setup/tree/main/pyannote)\n",
-    "* the `PYANNOTE_DATABASE_CONFIG` environment variable is set accordingly. \n",
+    "* the `PYANNOTE_DATABASE_CONFIG` environment variable is set accordingly. Remember to restart runtime before attempting to use database.\n",
     "\n",
     "See [`pyannote.database` documentation](https://github.com/pyannote/pyannote-database#pyannote-database) to learn how to prepare your own dataset for training with `pyannote.audio`."
    ]


### PR DESCRIPTION
Added comment to restart kernel after setting the environment. Spent 1 hr on this stupid mistake.
This can also be added in tutorial code to copy behaviour from BUT repo.
```
BASE_DIR = os.getcwd()
env_path = os.path.join(BASE_DIR, 'AMI-diarization-setup/pyannote/database.yml')
os.environ["PYANNOTE_DATABASE_CONFIG"] = env_path
```