### PR TITLE
Add hf.co/pyannote/segmentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 
 ```python
-# 1. visit hf.co/pyannote/speaker-diarization and accept user conditions (only if requested)
+# 1. visit hf.co/pyannote/speaker-diarization and hf.co/pyannote/segmentation and accept user conditions (only if requested)
 # 2. visit hf.co/settings/tokens to create an access token (only if you had to go through 1.)
 # 3. instantiate pretrained speaker diarization pipeline
 from pyannote.audio import Pipeline


### PR DESCRIPTION
I also had to accept the user condition on https://hf.co/pyannote/segmentation.
Otherwise, I was receiving the following error:

`HTTPError: 403 Client Error: Forbidden for url: https://huggingface.co/pyannote/segmentation/resolve/2022.07/pytorch_model.bin (Request ID: <id>)`