### PR TITLE
Add support for soundfile 0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pytorch_lightning >=1.5.4,<1.7
 pytorch_metric_learning >=1.0.0,<2.0
 semver >=2.10.2,<3.0
 singledispatchmethod
-soundfile >=0.10.2,<0.11
+soundfile >=0.10.2,<0.12
 speechbrain >=0.5.12,<0.6
 torch >=1.9
 torch_audiomentations >= 0.11.0


### PR DESCRIPTION
See https://github.com/pyannote/pyannote-audio/issues/1096

Soundfile 0.11 was released 2 months ago, with improvements and better support for M1 macs: https://github.com/bastibe/python-soundfile/releases/tag/0.11.0