### PR TITLE
Fix AUROC to work with torchmetrics >=0.11 (bump required version to 0.11)

### DIFF
--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -30,7 +30,8 @@ from pyannote.database.protocol import (
     SpeakerDiarizationProtocol,
     SpeakerVerificationProtocol,
 )
-from torchmetrics import AUROC, Metric
+from torchmetrics import Metric
+from torchmetrics.classification import BinaryAUROC
 from tqdm import tqdm
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications
@@ -127,7 +128,7 @@ class SupervisedRepresentationLearningTaskMixin:
     def default_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
-        return AUROC(compute_on_step=False)
+        return BinaryAUROC(compute_on_step=False)
 
     def train__iter__(self):
         """Iterate over training samples

--- a/pyannote/audio/tasks/embedding/mixins.py
+++ b/pyannote/audio/tasks/embedding/mixins.py
@@ -128,7 +128,7 @@ class SupervisedRepresentationLearningTaskMixin:
     def default_metric(
         self,
     ) -> Union[Metric, Sequence[Metric], Dict[str, Metric]]:
-        return BinaryAUROC(compute_on_step=False)
+        return BinaryAUROC(compute_on_cpu=True)
 
     def train__iter__(self):
         """Iterate over training samples

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -31,7 +31,8 @@ import numpy as np
 import torch
 from pyannote.core import Segment, SlidingWindowFeature
 from torch.utils.data._utils.collate import default_collate
-from torchmetrics import AUROC, Metric
+from torchmetrics import Metric
+from torchmetrics.classification import BinaryAUROC, MultilabelAUROC, MulticlassAUROC
 
 from pyannote.audio.core.io import AudioFile
 from pyannote.audio.core.task import Problem
@@ -129,7 +130,16 @@ class SegmentationTaskMixin:
         """Returns macro-average of the area under the ROC curve"""
 
         num_classes = len(self.specifications.classes)
-        return AUROC(num_classes, pos_label=1, average="macro", compute_on_step=False)
+        if self.specifications.problem == Problem.BINARY_CLASSIFICATION:
+            return BinaryAUROC(average="macro", compute_on_step=False)
+        elif self.specifications.problem == Problem.MULTI_LABEL_CLASSIFICATION:
+            return MultilabelAUROC(num_classes, average="macro", compute_on_step=True)
+        elif self.specifications.problem == Problem.MONO_LABEL_CLASSIFICATION:
+            return MulticlassAUROC(num_classes, average="macro", compute_on_step=False)
+        else:
+            raise RuntimeError(
+                f"The {self.specifications.problem} problem type hasn't been given a default segmentation metric yet."
+            )
 
     def adapt_y(self, one_hot_y: np.ndarray) -> np.ndarray:
         raise NotImplementedError(

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -131,11 +131,11 @@ class SegmentationTaskMixin:
 
         num_classes = len(self.specifications.classes)
         if self.specifications.problem == Problem.BINARY_CLASSIFICATION:
-            return BinaryAUROC(average="macro", compute_on_step=False)
+            return BinaryAUROC(compute_on_cpu=True)
         elif self.specifications.problem == Problem.MULTI_LABEL_CLASSIFICATION:
-            return MultilabelAUROC(num_classes, average="macro", compute_on_step=True)
+            return MultilabelAUROC(num_classes, average="macro", compute_on_cpu=True)
         elif self.specifications.problem == Problem.MONO_LABEL_CLASSIFICATION:
-            return MulticlassAUROC(num_classes, average="macro", compute_on_step=False)
+            return MulticlassAUROC(num_classes, average="macro", compute_on_cpu=True)
         else:
             raise RuntimeError(
                 f"The {self.specifications.problem} problem type hasn't been given a default segmentation metric yet."

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ speechbrain >=0.5.12,<0.6
 torch >=1.9
 torch_audiomentations >= 0.11.0
 torchaudio >=0.10,<1.0
-torchmetrics >=0.6,<1.0
+torchmetrics >=0.10,<1.0
 typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ speechbrain >=0.5.12,<0.6
 torch >=1.9
 torch_audiomentations >= 0.11.0
 torchaudio >=0.10,<1.0
-torchmetrics >=0.10,<1.0
+torchmetrics >=0.11,<1.0
 typing_extensions


### PR DESCRIPTION
With torchmetrics 0.11, AUROC implemention has made a breaking change and now requires to specify the problem type (multiclass/multilabel/binary classification).
(see [v0.10 API](https://torchmetrics.readthedocs.io/en/v0.10.3/classification/auroc.html) vs [v0.11 API](https://torchmetrics.readthedocs.io/en/v0.11.0/classification/auroc.html))

This pull request fixes obsolete ("deprecated" in v0.10.x but still worked) AUROC uses and (should) allow unit tests to pass again.
It also bumps the required torchmetrics version to 0.10 because these new specialized AUROC didn't seem to exist before.

(It's possible I didn't use the right types of AUROC metrics)