### PR TITLE
Add support for multiple Pytorch Lightning loggers

### DIFF
--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -492,15 +492,16 @@ class SegmentationTaskMixin:
 
         plt.tight_layout()
 
-        if isinstance(self.model.logger, TensorBoardLogger):
-            self.model.logger.experiment.add_figure(
-                f"{self.logging_prefix}ValSamples", fig, self.model.current_epoch
-            )
-        elif isinstance(self.model.logger, MLFlowLogger):
-            self.model.logger.experiment.log_figure(
-                run_id=self.model.logger.run_id,
-                figure=fig,
-                artifact_file=f"{self.logging_prefix}ValSamples_epoch{self.model.current_epoch}.png",
-            )
+        for logger in self.model.loggers:
+            if isinstance(logger, TensorBoardLogger):
+                logger.experiment.add_figure(
+                    f"{self.logging_prefix}ValSamples", fig, self.model.current_epoch
+                )
+            elif isinstance(logger, MLFlowLogger):
+                logger.experiment.log_figure(
+                    run_id=logger.run_id,
+                    figure=fig,
+                    artifact_file=f"{self.logging_prefix}ValSamples_epoch{self.model.current_epoch}.png",
+                )
 
         plt.close(fig)

--- a/pyannote/audio/tasks/segmentation/segmentation.py
+++ b/pyannote/audio/tasks/segmentation/segmentation.py
@@ -699,16 +699,17 @@ class Segmentation(SegmentationTaskMixin, Task):
 
         plt.tight_layout()
 
-        if isinstance(self.model.logger, TensorBoardLogger):
-            self.model.logger.experiment.add_figure(
-                f"{self.logging_prefix}ValSamples", fig, self.model.current_epoch
-            )
-        elif isinstance(self.model.logger, MLFlowLogger):
-            self.model.logger.experiment.log_figure(
-                run_id=self.model.logger.run_id,
-                figure=fig,
-                artifact_file=f"{self.logging_prefix}ValSamples_epoch{self.model.current_epoch}.png",
-            )
+        for logger in self.model.loggers:
+            if isinstance(logger, TensorBoardLogger):
+                logger.experiment.add_figure(
+                    f"{self.logging_prefix}ValSamples", fig, self.model.current_epoch
+                )
+            elif isinstance(logger, MLFlowLogger):
+                logger.experiment.log_figure(
+                    run_id=logger.run_id,
+                    figure=fig,
+                    artifact_file=f"{self.logging_prefix}ValSamples_epoch{self.model.current_epoch}.png",
+                )
 
         plt.close(fig)
 


### PR DESCRIPTION
Training crashes on validation while logging the model output figures when the pytorch lightning `Trainer` is given a list of loggers. This is because `LightningModule`s' `.logger` variable is accessed but is None when there are multiple loggers.

The proposed solution is to iterate on the `.loggers` variable, which works for the general case.