### PR TITLE
Remove upper limit for einops

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asteroid-filterbanks >=0.4,<0.5
 backports.cached_property
-einops >=0.3,<0.4.0
+einops >=0.3
 hmmlearn >=0.2.7,<0.3
 huggingface_hub >= 0.8.1
 networkx >= 2.6,<3.0


### PR DESCRIPTION
Remove the upper limit for einops since this makes the python package incompatible with other python dependencies.    

One good reason for not setting an upper limit: https://iscinumpy.dev/post/bound-version-constraints/