### PR TITLE
Replace np.int with int

### DIFF
--- a/pyannote/audio/tasks/segmentation/multilabel.py
+++ b/pyannote/audio/tasks/segmentation/multilabel.py
@@ -187,9 +187,9 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
 
         # discretize chunk annotations at model output resolution
         start = np.maximum(chunk_annotations["start"], chunk.start) - chunk.start
-        start_idx = np.floor(start / resolution).astype(np.int)
+        start_idx = np.floor(start / resolution).astype(int)
         end = np.minimum(chunk_annotations["end"], chunk.end) - chunk.start
-        end_idx = np.ceil(end / resolution).astype(np.int)
+        end_idx = np.ceil(end / resolution).astype(int)
 
         # frame-level targets (-1 for un-annotated classes)
         y = -np.ones((num_frames, len(self.classes)), dtype=np.int8)

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -179,9 +179,9 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
 
         # discretize chunk annotations at model output resolution
         start = np.maximum(chunk_annotations["start"], chunk.start) - chunk.start
-        start_idx = np.floor(start / resolution).astype(np.int)
+        start_idx = np.floor(start / resolution).astype(int)
         end = np.minimum(chunk_annotations["end"], chunk.end) - chunk.start
-        end_idx = np.ceil(end / resolution).astype(np.int)
+        end_idx = np.ceil(end / resolution).astype(int)
 
         # frame-level targets
         y = np.zeros((num_frames, 1), dtype=np.uint8)

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -347,9 +347,9 @@ class SpeakerDiarization(SegmentationTaskMixin, Task):
 
         # discretize chunk annotations at model output resolution
         start = np.maximum(chunk_annotations["start"], chunk.start) - chunk.start
-        start_idx = np.floor(start / resolution).astype(np.int)
+        start_idx = np.floor(start / resolution).astype(int)
         end = np.minimum(chunk_annotations["end"], chunk.end) - chunk.start
-        end_idx = np.ceil(end / resolution).astype(np.int)
+        end_idx = np.ceil(end / resolution).astype(int)
 
         # get list and number of labels for current scope
         labels = list(np.unique(chunk_annotations[label_scope_key]))

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -161,9 +161,9 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
 
         # discretize chunk annotations at model output resolution
         start = np.maximum(chunk_annotations["start"], chunk.start) - chunk.start
-        start_idx = np.floor(start / resolution).astype(np.int)
+        start_idx = np.floor(start / resolution).astype(int)
         end = np.minimum(chunk_annotations["end"], chunk.end) - chunk.start
-        end_idx = np.ceil(end / resolution).astype(np.int)
+        end_idx = np.ceil(end / resolution).astype(int)
 
         # frame-level targets
         y = np.zeros((num_frames, 1), dtype=np.uint8)


### PR DESCRIPTION
`np.int`, which aliases the builtin `int`, is deprecated and removed from recent versions. This replaces instances of `np.int` with `int`.