### PR TITLE
Fix remaining `mono=True` initializations of `Audio`

### DIFF
--- a/pyannote/audio/interactive/common/utils.py
+++ b/pyannote/audio/interactive/common/utils.py
@@ -35,7 +35,7 @@ from pyannote.audio import Audio
 
 class AudioForProdigy(Audio):
     def __init__(self):
-        super().__init__(sample_rate=16000, mono=True)
+        super().__init__(sample_rate=16000, mono="downmix")
 
     def crop(self, path: Path, excerpt: Segment) -> Text:
         waveform, _ = super().crop(path, excerpt)

--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -165,7 +165,7 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
             self._embedding = PretrainedSpeakerEmbedding(
                 self.embedding, use_auth_token=use_auth_token
             )
-            self._audio = Audio(sample_rate=self._embedding.sample_rate, mono=True)
+            self._audio = Audio(sample_rate=self._embedding.sample_rate, mono="downmix")
             metric = self._embedding.metric
 
         try:


### PR DESCRIPTION
After changing the behavior of `Audio` initialization, not all codebase was updated. As a consequence, for example, standard diarization pipeline from Huggingface now crashes with `AssertionErrors` on multi-channel audio. This PR fixes this.