### PR TITLE
Fix instantaneous speaker count exceeding `max_speakers` or detected number of clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - fix(pipeline): add missing "embedding" hook call in `SpeakerDiarization`
 - fix(pipeline): fix `AgglomerativeClustering` to honor `num_clusters` when provided
+- fix(pipeline): fix frame-wise speaker count exceeding `max_speakers` or detected `num_speakers` in `SpeakerDiarization` pipeline
 
 ### Improvements
 
@@ -26,6 +27,8 @@
 - BREAKING(setup): remove `onnxruntime` dependency.
   You can still use ONNX `hbredin/wespeaker-voxceleb-resnet34-LM` but you will have to install `onnxruntime` yourself.
 - BREAKING(pipeline): remove `logging_hook` (use `ArtifactHook` instead)
+- BREAKING(pipeline): remove `onset` and `offset` parameter in `SpeakerDiarizationMixin.speaker_count`  
+  You should now binarize segmentations before passing them to `speaker_count`
 
 ## Version 3.0.1 (2023-09-28)
 

--- a/pyannote/audio/pipelines/clustering.py
+++ b/pyannote/audio/pipelines/clustering.py
@@ -253,7 +253,6 @@ class BaseClustering(Pipeline):
             hard_clusters = np.zeros((num_chunks, num_speakers), dtype=np.int8)
             soft_clusters = np.ones((num_chunks, num_speakers, 1))
             centroids = np.mean(train_embeddings, axis=0, keepdims=True)
-
             return hard_clusters, soft_clusters, centroids
 
         train_clusters = self.cluster(

--- a/pyannote/audio/pipelines/resegmentation.py
+++ b/pyannote/audio/pipelines/resegmentation.py
@@ -39,6 +39,7 @@ from pyannote.audio.pipelines.utils import (
     get_model,
 )
 from pyannote.audio.utils.permutation import mae_cost_func, permutate
+from pyannote.audio.utils.signal import binarize
 
 
 class Resegmentation(SpeakerDiarizationMixin, Pipeline):
@@ -181,11 +182,17 @@ class Resegmentation(SpeakerDiarizationMixin, Pipeline):
 
         hook("segmentation", segmentations)
 
-        # estimate frame-level number of instantaneous speakers
-        count = self.speaker_count(
+        # binarize segmentations before speaker counting
+        binarized_segmentations: SlidingWindowFeature = binarize(
             segmentations,
             onset=self.onset,
             offset=self.offset,
+            initial_state=False,
+        )
+
+        # estimate frame-level number of instantaneous speakers
+        count = self.speaker_count(
+            binarized_segmentations,
             warm_up=(self.warm_up, self.warm_up),
             frames=self._frames,
         )

--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -533,7 +533,7 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
         # centroids: (num_speakers, dimension)
 
         # number of detected clusters is the number of different speakers
-        num_different_speakers = centroids.shape[0]
+        num_different_speakers = int(np.max(hard_clusters) + 1)
 
         # detected number of speakers can still be out of bounds
         # (specifically, lower than `min_speakers`), since there could be too few embeddings
@@ -607,13 +607,17 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
         if not return_embeddings:
             return diarization
 
+        # this can happen when we use OracleClustering
+        if centroids is None:
+            return diarization, None
+
         # The number of centroids may be smaller than the number of speakers
         # in the annotation. This can happen if the number of active speakers
         # obtained from `speaker_count` for some frames is larger than the number
         # of clusters obtained from `clustering`. In this case, we append zero embeddings
         # for extra speakers
         if len(diarization.labels()) > centroids.shape[0]:
-            centroids = np.pad(centroids, (0, len(diarization.labels()) - centroids.shape[0]))
+            centroids = np.pad(centroids, ((0, len(diarization.labels()) - centroids.shape[0]), (0, 0)))
 
         # re-order centroids so that they match
         # the order given by diarization.labels()

--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -533,14 +533,15 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
         # centroids: (num_speakers, dimension)
 
         # number of detected clusters is the number of different speakers
-        num_different_speakers = int(np.max(hard_clusters) + 1)
+        num_different_speakers = np.max(hard_clusters) + 1
 
         # detected number of speakers can still be out of bounds
         # (specifically, lower than `min_speakers`), since there could be too few embeddings
         # to make enough clusters with a given minimum cluster size.
         if num_different_speakers < min_speakers or num_different_speakers > max_speakers:
             warnings.warn(textwrap.dedent(
-                f"""The detected number of speakers ({num_different_speakers}) is outside
+                f"""
+                The detected number of speakers ({num_different_speakers}) is outside
                 the given bounds [{min_speakers}, {max_speakers}]. This can happen if the
                 given audio file is too short to contain {min_speakers} or more speakers.
                 Try to lower the desired minimal number of speakers.

--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -25,6 +25,8 @@
 import functools
 import itertools
 import math
+import textwrap
+import warnings
 from typing import Callable, Optional, Text, Union
 
 import numpy as np
@@ -533,11 +535,18 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
 
         # number of detected clusters is the number of different speakers
         num_different_speakers = centroids.shape[0]
-        # quick sanity check
-        assert (
-            num_different_speakers >= min_speakers
-            and num_different_speakers <= max_speakers
-        )
+
+        # detected number of speakers can still be out of bounds
+        # (specifically, lower than `min_speakers`), since there could be too few embeddings
+        # to make enough clusters with a given minimum cluster size.
+        if num_different_speakers < min_speakers or num_different_speakers > max_speakers:
+            warnings.warn(textwrap.dedent(
+                f"""The detected number of speakers ({num_different_speakers}) is outside
+                the given bounds [{min_speakers}, {max_speakers}]. This can happen if the
+                given audio file is too short to contain {min_speakers} or more speakers.
+                Try to lower the desired minimal number of speakers.
+                """
+            ))
 
         # during counting, we could possibly overcount the number of instantaneous
         # speakers due to segmentation errors, so we cap the maximum instantaneous number

--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -493,7 +493,6 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
         # estimate frame-level number of instantaneous speakers
         count = self.speaker_count(
             binarized_segmentations,
-            max_speakers,
             frames=self._frames,
             warm_up=(0.0, 0.0),
         )
@@ -550,8 +549,8 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
 
         # during counting, we could possibly overcount the number of instantaneous
         # speakers due to segmentation errors, so we cap the maximum instantaneous number
-        # of speakers by the number of detected clusters
-        count.data = np.minimum(count.data, num_different_speakers)
+        # of speakers by the `max_speakers` value
+        count.data = np.minimum(count.data, max_speakers)
 
         # reconstruct discrete diarization from raw hard clusters
 

--- a/pyannote/audio/pipelines/utils/diarization.py
+++ b/pyannote/audio/pipelines/utils/diarization.py
@@ -121,7 +121,6 @@ class SpeakerDiarizationMixin:
     @staticmethod
     def speaker_count(
         binarized_segmentations: SlidingWindowFeature,
-        max_speakers: Union[int, float] = np.inf,
         warm_up: Tuple[float, float] = (0.1, 0.1),
         frames: SlidingWindow = None,
     ) -> SlidingWindowFeature:
@@ -131,8 +130,6 @@ class SpeakerDiarizationMixin:
         ----------
         binarized_segmentations : SlidingWindowFeature
             (num_chunks, num_frames, num_classes)-shaped binarized scores.
-        max_speakers : int or np.inf
-            Maximum number of speakers allowed. Counts will not exceed this number
         warm_up : (float, float) tuple, optional
             Left/right warm up ratio of chunk duration.
             Defaults to (0.1, 0.1), i.e. 10% on both sides.
@@ -155,7 +152,6 @@ class SpeakerDiarizationMixin:
             missing=0.0,
             skip_average=False,
         )
-        count.data[count.data > max_speakers] = max_speakers
         count.data = np.rint(count.data).astype(np.uint8)
 
         return count

--- a/pyannote/audio/pipelines/utils/diarization.py
+++ b/pyannote/audio/pipelines/utils/diarization.py
@@ -121,7 +121,7 @@ class SpeakerDiarizationMixin:
     @staticmethod
     def speaker_count(
         binarized_segmentations: SlidingWindowFeature,
-        max_speakers: Union[int, float],
+        max_speakers: Union[int, float] = np.inf,
         warm_up: Tuple[float, float] = (0.1, 0.1),
         frames: SlidingWindow = None,
     ) -> SlidingWindowFeature:


### PR DESCRIPTION
The number of labels in the diarization result was based on the result of `speaker_count` method, which did not account for `max_speakers` variable or the actual detected number of speakers after clusterization. This led to the appearance of additional erroneous speakers in the diarization result, so the output could have more labels than provided `max_speakers` or more labels than number of clusters detected by the clusterization algorithm. This PR fixes this.

Additionally, the extra binarization step was removed from `speaker_count` method - now it accepts segmentations in already binarized form, so no extra binarization step in the pipeline is done.
