### PR TITLE
 Changed install requirements for hmmlearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asteroid-filterbanks >=0.4,<0.5
 backports.cached_property
 einops >=0.3,<0.4.0
-hmmlearn >=0.2.7,<0.3
+hmmlearn >=0.2.7
 huggingface_hub >= 0.8.1
 networkx >= 2.6,<3.0
 omegaconf >=2.1,<3.0


### PR DESCRIPTION
Updated install requirements for hmmlearn to allow it to be used for Mac M1 devices and make it compatible with the new hmmlearn 0.3.0. It should fix problem #1321