### PR TITLE
doc: fix typo in diarization usage with return embeddings

### DIFF
--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -99,7 +99,7 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
     >>> diarization = pipeline("/path/to/audio.wav", min_speakers=2, max_speakers=10)
 
     # perform diarization and get one representative embedding per speaker
-    >>> diarization, embeddings = pipeline("/path/to/audio.wav", return_embedding=True)
+    >>> diarization, embeddings = pipeline("/path/to/audio.wav", return_embeddings=True)
     >>> for s, speaker in enumerate(diarization.labels()):
     ...     # embeddings[s] is the embedding of speaker `speaker`
 


### PR DESCRIPTION
add missing "s" to  `return_embeddings`  based on the [actual parameter spelling](https://github.com/pyannote/pyannote-audio/blob/f3935464065f743496df9558b7badaaa5a827c9c/pyannote/audio/pipelines/speaker_diarization.py#L429)