### PR TITLE
[do not merge] Fix torchaudio backend import in recent torchaudio versions

### DIFF
--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -34,7 +34,7 @@ from pyannote.database.protocol import SegmentationProtocol, SpeakerDiarizationP
 from pyannote.database.protocol.protocol import Scope, Subset
 from pytorch_lightning.loggers import MLFlowLogger, TensorBoardLogger
 from torch.utils.data._utils.collate import default_collate
-from torchaudio.backend.common import AudioMetaData
+from torchaudio._backend.common import AudioMetaData
 from torchmetrics import Metric
 from torchmetrics.classification import BinaryAUROC, MulticlassAUROC, MultilabelAUROC
 


### PR DESCRIPTION
EDIT: The backwards compatibility issue in torchaudio was unintended and will be fixed by the author there

Ran into https://discuss.pytorch.org/t/no-module-named-torchaudio-backend-common/186937 while testing whisperX with rocm5.6. Turns out that in https://github.com/pytorch/audio/pull/3549 parts of the `torchaudio.backend` were moved under `torchaudio._backend`.

This fixes said issue. Though not sure how it affects backwards compatibility etc, but likely something that will need to be changed at some point.