### PR TITLE
Fix val_monitor "ValLoss" -> "loss/val" in multilabel task

### DIFF
--- a/pyannote/audio/tasks/segmentation/multilabel.py
+++ b/pyannote/audio/tasks/segmentation/multilabel.py
@@ -277,4 +277,4 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
         pytorch_lightning.callbacks.EarlyStopping
         """
 
-        return "ValLoss", "min"
+        return "loss/val", "min"


### PR DESCRIPTION
#1385 updated one string incorrectly