### PR TITLE
Fix missing install candidate for ONNX Runtime on Apple Silicon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ einops >=0.6.0
 huggingface_hub >= 0.13.0
 lightning >= 2.0.1
 omegaconf >=2.1,<3.0
-onnxruntime-gpu >= 1.16.0
+onnxruntime-gpu >= 1.16.0; (sys_platform != "darwin" and platform_system != "Darwin") or platform_machine != "arm64"
+onnxruntime-silicon >= 1.16.0; (sys_platform == "darwin" or platform_system == "Darwin") and platform_machine == "arm64"
 pyannote.core >= 5.0.0
 pyannote.database >= 5.0.1
 pyannote.metrics >= 3.2


### PR DESCRIPTION
This patch alters the requirements to use another ONNX runtime package which provides pre-build wheels for Apple Silicon in case of running on arm64/M1/M2 Mac.

Fixes #1505