### PR TITLE
Fix missing `.cpu()` call causing WeSpeaker embedding pipeline to crash

### DIFF
--- a/pyannote/audio/pipelines/speaker_verification.py
+++ b/pyannote/audio/pipelines/speaker_verification.py
@@ -606,7 +606,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
 
             embeddings[f] = self.session_.run(
                 output_names=["embs"],
-                input_feed={"feats": masked_feature.numpy()[None]},
+                input_feed={"feats": masked_feature.cpu().numpy()[None]},
             )[0][0]
 
         return embeddings


### PR DESCRIPTION
## Problem

When `waveform` and `masks` are both on GPU, the WeSpeaker pipeline crashes because it can't convert features to numpy without moving the tensor to CPU first.

Also mentioned here: https://github.com/juanmc2005/diart/pull/188

## Minimal Reproducible Example

```python
import torch
from pyannote.audio.pipelines.speaker_verification import PretrainedSpeakerEmbedding

model = PretrainedSpeakerEmbedding("hbredin/wespeaker-voxceleb-resnet34-LM")
model.to(torch.device("cuda"))

waveform = torch.randn(4, 1, 80000).cuda()
weights = torch.rand(4, 300).cuda()

emb = model(waveform, weights)

print(emb.shape)
```