### PR TITLE
fix: moving the operations to the GPU if GPU available

### DIFF
--- a/pyannote/audio/pipelines/speaker_diarization.py
+++ b/pyannote/audio/pipelines/speaker_diarization.py
@@ -338,6 +338,10 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
         for i, batch in enumerate(batches, 1):
             waveforms, masks = zip(*filter(lambda b: b[0] is not None, batch))
 
+            if torch.cuda.is_available():
+                waveforms = tuple([x.cuda() for x in waveforms])
+                masks = tuple([x.cuda() for x in masks])
+
             waveform_batch = torch.vstack(waveforms)
             # (batch_size, 1, num_samples) torch.Tensor
 

--- a/pyannote/audio/pipelines/speaker_verification.py
+++ b/pyannote/audio/pipelines/speaker_verification.py
@@ -481,7 +481,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
         dummy_waveforms = torch.rand(1, 1, 16000)
         features = self.compute_fbank(dummy_waveforms)
         embeddings = self.session_.run(
-            output_names=["embs"], input_feed={"feats": features.numpy()}
+            output_names=["embs"], input_feed={"feats": features.cpu().numpy()}
         )[0]
         _, dimension = embeddings.shape
         return dimension
@@ -504,7 +504,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
                 continue
 
             embeddings = self.session_.run(
-                output_names=["embs"], input_feed={"feats": features.numpy()}
+                output_names=["embs"], input_feed={"feats": features.cpu().numpy()}
             )[0]
 
             if np.any(np.isnan(embeddings)):
@@ -583,7 +583,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
 
         if masks is None:
             embeddings = self.session_.run(
-                output_names=["embs"], input_feed={"feats": features.numpy()}
+                output_names=["embs"], input_feed={"feats": features.cpu().numpy()}
             )[0]
 
             return embeddings
@@ -606,7 +606,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
 
             embeddings[f] = self.session_.run(
                 output_names=["embs"],
-                input_feed={"feats": masked_feature.numpy()[None]},
+                input_feed={"feats": masked_feature.cpu().numpy()[None]},
             )[0][0]
 
         return embeddings


### PR DESCRIPTION
According my testing, before the code modifications, the 8 speaker diarization processes running on 8 GPUs(A100) separately of the same node, with some operations still on the CPU, the RTF (Real-Time Factor) was 3.32, After moving the operations to the GPU, the RTF reached 0.015. On V100, the RFT reached 0.02.