### PR TITLE
fix: compute fbank on selected device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - BREAKING(pipeline): remove `logging_hook` (use `ArtifactHook` instead)
 - fix(pipeline): add missing "embedding" hook call in `SpeakerDiarization`
 - feat(utils): add `"soft"` option to `Powerset.to_multilabel`
+- improve(pipeline): compute `fbank` on GPU when requested
 
 ## Version 3.0.1 (2023-09-28)
 

--- a/pyannote/audio/pipelines/speaker_verification.py
+++ b/pyannote/audio/pipelines/speaker_verification.py
@@ -556,6 +556,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
                 for waveform in waveforms
             ]
         )
+
         return features - torch.mean(features, dim=1, keepdim=True)
 
     def __call__(
@@ -578,12 +579,12 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
         batch_size, num_channels, num_samples = waveforms.shape
         assert num_channels == 1
 
-        features = self.compute_fbank(waveforms)
+        features = self.compute_fbank(waveforms.to(self.device))
         _, num_frames, _ = features.shape
 
         if masks is None:
             embeddings = self.session_.run(
-                output_names=["embs"], input_feed={"feats": features.numpy()}
+                output_names=["embs"], input_feed={"feats": features.numpy(force=True)}
             )[0]
 
             return embeddings
@@ -606,7 +607,7 @@ class WeSpeakerPretrainedSpeakerEmbedding(BaseInference):
 
             embeddings[f] = self.session_.run(
                 output_names=["embs"],
-                input_feed={"feats": masked_feature.numpy()[None]},
+                input_feed={"feats": masked_feature.numpy(force=True)[None]},
             )[0][0]
 
         return embeddings


### PR DESCRIPTION
@asr-pub: this is a more generic attempt at solving #1522 as it uses the internal `self.device` that can be set by `WeSpeakerPretrainedEmbeddding.to(device)` (and does not force using GPU when available). Can you please try it out and confirm that this solves your issue?

@juanmc2005: side effect of this PR is that it should solved #1518. Can you please try it out and confirm?