### PR TITLE
fix: force nb clusters to match target only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(pipeline): add missing "embedding" hook call in `SpeakerDiarization`
 - feat(utils): add `"soft"` option to `Powerset.to_multilabel`
 - improve(pipeline): compute `fbank` on GPU when requested
+- fix(pipeline): fix `AgglomerativeClustering` to `num_clusters` when provided
 
 ## Version 3.0.1 (2023-09-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - fix(pipeline): add missing "embedding" hook call in `SpeakerDiarization`
 - feat(utils): add `"soft"` option to `Powerset.to_multilabel`
 - improve(pipeline): compute `fbank` on GPU when requested
-- fix(pipeline): fix `AgglomerativeClustering` to `num_clusters` when provided
+- fix(pipeline): fix `AgglomerativeClustering` to honor `num_clusters` when provided
 
 ## Version 3.0.1 (2023-09-28)
 

--- a/pyannote/audio/pipelines/clustering.py
+++ b/pyannote/audio/pipelines/clustering.py
@@ -386,7 +386,8 @@ class AgglomerativeClustering(BaseClustering):
         elif num_large_clusters > max_clusters:
             num_clusters = max_clusters
 
-        if num_clusters is not None:
+        # look for perfect candidate if necessary
+        if num_clusters is not None and num_large_clusters != num_clusters:
             # switch stopping criterion from "inter-cluster distance" stopping to "iteration index"
             _dendrogram = np.copy(dendrogram)
             _dendrogram[:, 2] = np.arange(num_embeddings - 1)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from pyannote.audio.pipelines.clustering import AgglomerativeClustering
+
+
+def test_agglomerative_clustering_num_cluster():
+    """
+    Make sure AgglomerativeClustering doesn't "over-merge" clusters when initial
+    clustering already matches target num_clusters, cf
+    https://github.com/pyannote/pyannote-audio/issues/1525
+    """
+
+    # 2 embeddings different enough
+    embeddings = np.array([[1.0, 1.0, 1.0, 1.0], [1.0, 2.0, 1.0, 2.0]])
+
+    # clustering with params that should yield 1 cluster per embedding
+    clustering = AgglomerativeClustering().instantiate(
+        {
+            "method": "centroid",
+            "min_cluster_size": 0,
+            "threshold": 0.0,
+        }
+    )
+
+    # request 2 clusters
+    clusters = clustering.cluster(
+        embeddings=embeddings, min_clusters=2, max_clusters=2, num_clusters=2
+    )
+    assert np.array_equal(clusters, np.array([0, 1]))


### PR DESCRIPTION
Fixes #1525.  I can reuse the reproduction example as a test if you think it's a good idea.