### PR TITLE
Make val_monitor a parameter of the Task constructor

### DIFF
--- a/pyannote/audio/tasks/embedding/arcface.py
+++ b/pyannote/audio/tasks/embedding/arcface.py
@@ -23,7 +23,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Sequence, Union
+from typing import Dict, Sequence, Text, Tuple, Union
 
 import pytorch_metric_learning.losses
 from pyannote.database import Protocol
@@ -73,6 +73,11 @@ class SupervisedRepresentationLearningWithArcFace(
     metric : optional
         Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
         Defaults to AUROC (area under the ROC curve).
+    val_monitor : Tuple[Text, Text], optional
+        Tuple (monitor, mode) with `monitor` the name of the quantity (eg 'loss/val')
+        to monitor, `mode` either 'min' or 'max' (mini/maximizing the quantity).
+        Useful for model checkpointing or early stopping.
+        Defaults to the first metric of the task.
     """
 
     #  TODO: add a ".metric" property that tells how speaker embedding trained with this approach
@@ -92,8 +97,8 @@ class SupervisedRepresentationLearningWithArcFace(
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
         metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        val_monitor: Tuple[Text, Text] = None,
     ):
-
         self.num_chunks_per_class = num_chunks_per_class
         self.num_classes_per_batch = num_classes_per_batch
 
@@ -109,10 +114,10 @@ class SupervisedRepresentationLearningWithArcFace(
             pin_memory=pin_memory,
             augmentation=augmentation,
             metric=metric,
+            val_monitor=val_monitor,
         )
 
     def setup_loss_func(self):
-
         _, embedding_size = self.model(self.model.example_input_array).shape
 
         self.model.loss_func = pytorch_metric_learning.losses.ArcFaceLoss(

--- a/pyannote/audio/tasks/segmentation/multilabel.py
+++ b/pyannote/audio/tasks/segmentation/multilabel.py
@@ -79,6 +79,11 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
     metric : optional
         Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
         Defaults to AUROC (area under the ROC curve).
+    val_monitor : Tuple[Text, Text], optional
+        Tuple (monitor, mode) with `monitor` the name of the quantity (eg 'loss/val')
+        to monitor, `mode` either 'min' or 'max' (mini/maximizing the quantity).
+        Useful for model checkpointing or early stopping.
+        Defaults to ('loss/val', 'min').
     """
 
     def __init__(
@@ -94,6 +99,7 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
         metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        val_monitor: Tuple[Text, Text] = ("loss/val", "min"),
     ):
         if not isinstance(protocol, SegmentationProtocol):
             raise ValueError(
@@ -109,6 +115,7 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             augmentation=augmentation,
             metric=metric,
+            val_monitor=val_monitor,
         )
 
         self.balance = balance
@@ -257,24 +264,3 @@ class MultiLabelSegmentation(SegmentationTaskMixin, Task):
             logger=True,
         )
         return {"loss": loss}
-
-    @property
-    def val_monitor(self):
-        """Quantity (and direction) to monitor
-
-        Useful for model checkpointing or early stopping.
-
-        Returns
-        -------
-        monitor : str
-            Name of quantity to monitor.
-        mode : {'min', 'max}
-            Minimize
-
-        See also
-        --------
-        pytorch_lightning.callbacks.ModelCheckpoint
-        pytorch_lightning.callbacks.EarlyStopping
-        """
-
-        return "loss/val", "min"

--- a/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
+++ b/pyannote/audio/tasks/segmentation/overlapped_speech_detection.py
@@ -88,6 +88,11 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
     metric : optional
         Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
         Defaults to AUROC (area under the ROC curve).
+    val_monitor : Tuple[Text, Text], optional
+        Tuple (monitor, mode) with `monitor` the name of the quantity (eg 'loss/val')
+        to monitor, `mode` either 'min' or 'max' (mini/maximizing the quantity).
+        Useful for model checkpointing or early stopping.
+        Defaults to the first metric of the task.
     """
 
     OVERLAP_DEFAULTS = {"probability": 0.5, "snr_min": 0.0, "snr_max": 10.0}
@@ -105,6 +110,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
         metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        val_monitor: Tuple[Text, Text] = None,
     ):
         super().__init__(
             protocol,
@@ -115,6 +121,7 @@ class OverlappedSpeechDetection(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             augmentation=augmentation,
             metric=metric,
+            val_monitor=val_monitor,
         )
 
         self.specifications = Specifications(

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -110,6 +110,11 @@ class SpeakerDiarization(SegmentationTaskMixin, Task):
     metric : optional
         Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
         Defaults to AUROC (area under the ROC curve).
+    val_monitor : Tuple[Text, Text], optional
+        Tuple (monitor, mode) with `monitor` the name of the quantity (eg 'loss/val')
+        to monitor, `mode` either 'min' or 'max' (mini/maximizing the quantity).
+        Useful for model checkpointing or early stopping.
+        Defaults to the first metric of the task.
 
     References
     ----------
@@ -140,6 +145,7 @@ class SpeakerDiarization(SegmentationTaskMixin, Task):
         augmentation: BaseWaveformTransform = None,
         vad_loss: Literal["bce", "mse"] = None,
         metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        val_monitor: Tuple[Text, Text] = None,
         max_num_speakers: int = None,  # deprecated in favor of `max_speakers_per_chunk``
         loss: Literal["bce", "mse"] = None,  # deprecated
     ):
@@ -152,6 +158,7 @@ class SpeakerDiarization(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             augmentation=augmentation,
             metric=metric,
+            val_monitor=val_monitor,
         )
 
         if not isinstance(protocol, SpeakerDiarizationProtocol):

--- a/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -74,6 +74,11 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
     metric : optional
         Validation metric(s). Can be anything supported by torchmetrics.MetricCollection.
         Defaults to AUROC (area under the ROC curve).
+    val_monitor : Tuple[Text, Text], optional
+        Tuple (monitor, mode) with `monitor` the name of the quantity (eg 'loss/val')
+        to monitor, `mode` either 'min' or 'max' (mini/maximizing the quantity).
+        Useful for model checkpointing or early stopping.
+        Defaults to the first metric of the task.
     """
 
     def __init__(
@@ -88,6 +93,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
         pin_memory: bool = False,
         augmentation: BaseWaveformTransform = None,
         metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        val_monitor: Tuple[Text, Text] = None,
     ):
         super().__init__(
             protocol,
@@ -98,6 +104,7 @@ class VoiceActivityDetection(SegmentationTaskMixin, Task):
             pin_memory=pin_memory,
             augmentation=augmentation,
             metric=metric,
+            val_monitor=val_monitor,
         )
 
         self.balance = balance


### PR DESCRIPTION
It's currently impossible to change a task `val_monitor` without changing the class definition (and it's not trivial to dynamically replace a `@property` definition)(but it can be done ...).

This PR adds a `val_monitor` parameter to (sub)task constructors. To change the default `val_monitor` of a task we can simply change the default parameter instead of overriding the property (see `multilabel.py`) (unless more advanced logic is needed). All existing code should still be working the same after this PR.