### PR TITLE
Add `balance_weights` to weight balanced batches

### DIFF
--- a/src/pyannote/audio/core/task.py
+++ b/src/pyannote/audio/core/task.py
@@ -256,7 +256,7 @@ class Task(lightning.LightningDataModule):
         num_workers: Optional[int] = None,
         pin_memory: bool = False,
         augmentation: Optional[BaseWaveformTransform] = None,
-        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric], None] = None,
     ):
         super().__init__()
 

--- a/src/pyannote/audio/models/segmentation/PyanNet.py
+++ b/src/pyannote/audio/models/segmentation/PyanNet.py
@@ -110,10 +110,13 @@ class PyanNet(Model):
             self.lstm = nn.ModuleList(
                 [
                     nn.LSTM(
-                        60
-                        if i == 0
-                        else lstm["hidden_size"] * (2 if lstm["bidirectional"] else 1),
-                        **one_layer_lstm
+                        (
+                            60
+                            if i == 0
+                            else lstm["hidden_size"]
+                            * (2 if lstm["bidirectional"] else 1)
+                        ),
+                        **one_layer_lstm,
                     )
                     for i in range(num_layers)
                 ]

--- a/src/pyannote/audio/tasks/segmentation/multilabel.py
+++ b/src/pyannote/audio/tasks/segmentation/multilabel.py
@@ -35,6 +35,7 @@ from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTask
+from pyannote.audio.utils.balance import TaskBalancingSpecifications
 
 
 class MultiLabelSegmentation(SegmentationTask):
@@ -66,10 +67,11 @@ class MultiLabelSegmentation(SegmentationTask):
         parts, only the remaining central part of each chunk is used for computing the
         loss during training, and for aggregating scores during inference.
         Defaults to 0. (i.e. no warm-up).
-    balance: Sequence[Text], optional
-        When provided, training samples are sampled uniformly with respect to these keys.
-        For instance, setting `balance` to ["database","subset"] will make sure that each
-        database & subset combination will be equally represented in the training samples.
+    balance: TaskBalancingSpecifications or Sequence[str] or dict, optional
+        Either a TaskBalancingSpecifications, its keys argument (i.e. a list), or
+        a dict with its kwargs (e.g. {'keys': ['database'], 'weighting_rules': {('AMI',): 3.0}})
+        Allows balancing of training samples according to multiple rules (e.g. see all datasets equally).
+        See the doc of `TaskBalancingSpecifications` for more details.
     weight: str, optional
         When provided, use this key to as frame-wise weight in loss function.
     batch_size : int, optional
@@ -96,13 +98,13 @@ class MultiLabelSegmentation(SegmentationTask):
         classes: Optional[List[str]] = None,
         duration: float = 2.0,
         warm_up: Union[float, Tuple[float, float]] = 0.0,
-        balance: Optional[Sequence[Text]] = None,
+        balance: TaskBalancingSpecifications | Sequence[str] | dict | None = None,
         weight: Optional[Text] = None,
         batch_size: int = 32,
         num_workers: Optional[int] = None,
         pin_memory: bool = False,
         augmentation: Optional[BaseWaveformTransform] = None,
-        metric: Union[Metric, Sequence[Metric], Dict[str, Metric]] = None,
+        metric: Union[Metric, Sequence[Metric], Dict[str, Metric], None] = None,
     ):
         if not isinstance(protocol, SegmentationProtocol):
             raise ValueError(
@@ -119,6 +121,7 @@ class MultiLabelSegmentation(SegmentationTask):
             augmentation=augmentation,
             metric=metric,
             cache=cache,
+            balance=balance,
         )
 
         self.balance = balance

--- a/src/pyannote/audio/tasks/segmentation/voice_activity_detection.py
+++ b/src/pyannote/audio/tasks/segmentation/voice_activity_detection.py
@@ -30,6 +30,7 @@ from torchmetrics import Metric
 
 from pyannote.audio.core.task import Problem, Resolution, Specifications
 from pyannote.audio.tasks.segmentation.mixins import SegmentationTask
+from pyannote.audio.utils.balance import TaskBalancingSpecifications
 
 
 class VoiceActivityDetection(SegmentationTask):
@@ -60,10 +61,11 @@ class VoiceActivityDetection(SegmentationTask):
         parts, only the remaining central part of each chunk is used for computing the
         loss during training, and for aggregating scores during inference.
         Defaults to 0. (i.e. no warm-up).
-    balance: Sequence[Text], optional
-        When provided, training samples are sampled uniformly with respect to these keys.
-        For instance, setting `balance` to ["database","subset"] will make sure that each
-        database & subset combination will be equally represented in the training samples.
+    balance: TaskBalancingSpecifications or Sequence[str] or dict, optional
+        Either a TaskBalancingSpecifications, its key argument, or
+        a dict with its kwargs (e.g. {'keys': ['database'], 'weighting_rules': {('AMI',): 3.0}})
+        Allows balancing of training samples according to multiple rules (e.g. see all datasets equally).
+        See the doc of `TaskBalancingSpecifications` for more details.
     weight: str, optional
         When provided, use this key to as frame-wise weight in loss function.
     batch_size : int, optional
@@ -89,7 +91,7 @@ class VoiceActivityDetection(SegmentationTask):
         cache: Optional[Union[str, None]] = None,
         duration: float = 2.0,
         warm_up: Union[float, Tuple[float, float]] = 0.0,
-        balance: Optional[Sequence[Text]] = None,
+        balance: TaskBalancingSpecifications | Sequence[str] | dict | None = None,
         weight: Optional[Text] = None,
         batch_size: int = 32,
         num_workers: Optional[int] = None,
@@ -107,6 +109,7 @@ class VoiceActivityDetection(SegmentationTask):
             augmentation=augmentation,
             metric=metric,
             cache=cache,
+            balance=balance,
         )
 
         self.balance = balance

--- a/src/pyannote/audio/utils/balance.py
+++ b/src/pyannote/audio/utils/balance.py
@@ -1,0 +1,273 @@
+# MIT License
+#
+# Copyright (c) 2025 CNRS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# AUTHORS
+# Alexis PLAQUET
+
+import itertools
+from typing import Any, Iterable
+
+ConditionValue = str | int | float | None
+WeightingRulesDict = (
+    None | dict[ConditionValue | Iterable[ConditionValue], float | tuple[float, int]]
+)
+InternalWeightingRulesDict = dict[Iterable[ConditionValue], tuple[float, int]]
+
+
+def _get_tuples_matching_power(tuple1: tuple[Any, ...], tuple2: tuple[Any, ...]) -> int:
+    """How much tuple1 matches tuple2. 0 = no match. 1=1 matching elt, etc
+    None elements are not counted but pass as matched.
+    e.g. (None,2,3,None) & (1,2,3,4) have a matching power of 2.
+    """
+    if tuple1 == tuple2:
+        return len(tuple1)
+
+    matching_elements: int = 0
+    for i in range(len(tuple1)):
+        if tuple1[i] == tuple2[i]:
+            matching_elements += 1
+        elif tuple1[i] is None:
+            continue
+        else:
+            return 0
+    return matching_elements
+
+
+def _to_tuple(
+    condition: ConditionValue | Iterable[ConditionValue],
+) -> tuple[ConditionValue]:
+    """Make sure the input str gets converted to an iterable of str (i.e. (str,))"""
+    if isinstance(condition, str) or not isinstance(condition, Iterable):
+        return (condition,)
+    else:
+        return tuple(condition)
+
+
+def _raise_weighting_rule_key(val: Any, balance: Iterable[str]) -> None:
+    """Raise error if the input value is not a valid weighting rule key."""
+    if not isinstance(val, Iterable):
+        raise ValueError(f"{val} is not a valid rule ley (not an iterable)", val)
+    elif len(val) > len(balance):
+        raise ValueError(
+            f"{val} is not a valid rule key ({len(val)} keys vs {len(balance)} available).",
+            val,
+        )
+    # TODO: check that each value is of a correct type (ConditionValue)
+
+
+def _raise_weighting_rule_value(val: Any) -> None:
+    """Raise error if the input value is not a valid weighting value."""
+    if not isinstance(val, tuple) or len(val) != 2:
+        raise ValueError(f"{val} is not a tuple (weight, priority)")
+    if not isinstance(val[0], float) or not isinstance(val[1], int):
+        raise ValueError(f"{val} has incorrect types, expected: (float, int)")
+
+
+def _sanitize_weighting_rules(
+    balance: Iterable[str], balance_weights: WeightingRulesDict
+) -> InternalWeightingRulesDict:
+    """Converts a `WeightingRulesDict` which supports a mix of single values/iterables,
+    to a `InternalWeightingRulesDict` which only contains tuples."""
+    if balance is None:
+        raise ValueError("`balance_weights` cannot be used without `balance`.")
+
+    balance_weights_fixed: WeightingRulesDict = {}
+    # Return empty dict if no balance_weights are provided
+    if balance_weights is None:
+        return balance_weights_fixed
+
+    # Convert individual values to tuples if needed and check the validity of the inputs.
+    for k, v in balance_weights.items():
+        # convert to tuple if needed
+        k_new = _to_tuple(k)
+        if isinstance(v, float):
+            v_new = (v, 0)
+        elif len(v) == 2 and isinstance(v[0], float) and isinstance(v[1], int):
+            v_new = v
+        else:
+            raise ValueError(
+                f"Value {v} is not a valid weighting value. Expected `priority` or `(weight, priority)`."
+            )
+
+        # raise error if not valid
+        _raise_weighting_rule_key(k_new, balance)
+        _raise_weighting_rule_value(v_new)
+
+        # create rule
+        balance_weights_fixed[k_new] = v_new
+    return balance_weights_fixed
+
+
+class TaskBalancingSpecifications:
+    def __init__(
+        self,
+        keys: Iterable[str],
+        weighting_rules: WeightingRulesDict = None,
+    ):
+        """Describe how to balance the content of batches in a task.
+
+        Parameters
+        ----------
+        keys : Iterable[str]
+            list of ProtocolFile keys that will be used to balance the batches.
+            e.g. ['database', 'channel', 'speaker']
+        weighting_rules : WeightingRulesDict, optional
+            Rules to define the sampling weight of combinations of keys.
+            This dictionary can be created dynamically using `add_weighting_rule`.
+            - Keys are tuples indicating a "condition": a matching combinations of keys. `None` means any value.
+            - Values are either a float (weight) or a tuple (weight, priority).
+            The weight controls the weighted sampling (higher = sampled more often).
+            The priority controls the order in which rules are checked (higher = more priority).
+            Cases not covered by rules are assigned a weight of 1.0. Default priority is 0.
+        See examples below for more details.
+
+        Example 1
+        ---------
+        >>> from pyannote.audio.utils import TaskBalancingSpecifications
+        >>> task_balance = TaskBalancingSpecifications(
+        ...     keys=['database'],
+        ...     weighting_rules={('AMI',): 3.0}
+        ... )
+        >>> # weights AMI files 3 times more than others
+
+        Example 2
+        ---------
+        >>> from pyannote.audio.utils import TaskBalancingSpecifications
+        >>> task_balance = TaskBalancingSpecifications(
+        ...     keys=['database', 'domain', 'channel'],
+        ...     weighting_rules={
+        ...         ('DIHARD',): 3.0,
+        ...         (None, 'audiobooks', 'CH01'): 0.1,
+        ...         ('DIHARD', 'audiobooks', None): (10.0, 2),
+        ...  })
+        >>> # DIHARD files are sampled with a weight of 3.
+        >>> # audiobooks files from channel CH01 are sampled with a weight of 0.1 (any database)
+        >>> # DIHARD audiobooks files (any channel) are sampled with a weight of 10.0, this takes priority over the previous rule
+        >>> # (the last rule's priority is set to 2)
+        """
+        self._keys: Iterable[str] = keys
+        self._weight_rules: InternalWeightingRulesDict = {}
+
+        self.set_weighting_rules(weighting_rules)
+
+    def set_weighting_rules(
+        self,
+        weighting_rules: WeightingRulesDict,
+    ) -> None:
+        """Set the weighting rules for the task balance (discards previous rules).
+
+        Parameters
+        ----------
+        weighting_rules : WeightingRulesDict
+            New weighting rules. See class docstring for more details.
+        """
+        self._weight_rules = _sanitize_weighting_rules(self.keys, weighting_rules)
+
+    def add_weighting_rule(
+        self,
+        condition: ConditionValue | tuple[ConditionValue],
+        weighting: float,
+        priority: int = 0,
+    ):
+        """Add one weighting rule.
+
+        Parameters
+        ----------
+        condition : ConditionValue | tuple[ConditionValue]
+            Balance values needed to apply the weighting rule.
+        weighting : float
+            Weighting rule (relative sampling weight when the condition is met).
+        priority : int, optional
+            Rule priority. The higher it is, the more priority is has over other conditions, by default 0
+        """
+        key = _to_tuple(condition)
+        value = (weighting, priority)
+
+        _raise_weighting_rule_key(key, self.keys)
+        _raise_weighting_rule_value(value)
+
+        self._weight_rules[key] = value
+
+    def remove_weighting_rule(self, condition: tuple[str]):
+        """Remove one rule.
+
+        Parameters
+        ----------
+        condition : tuple[str]
+            Condition of the rule to be removed.
+        """
+        del self._weight_rules[tuple]
+
+    def compute_weights(self, tuples: list[tuple[ConditionValue, ...]]) -> list[float]:
+        """Returns the relative weights of multiple conditions.
+
+        Parameters
+        ----------
+        tuples : list[tuple[ConditionValue]]
+            List of conditions, e.g. [('DIHARD', 0), ('AMI', 1), ('DIHARD', 1)]
+
+        Returns
+        -------
+        list[float]
+            List of weights, one per condition.
+            e.g. [1.0, 3.0, 1.0]
+        """
+        subchunks_weights: list[float] = []
+        for needed_tuple in tuples:
+            if len(needed_tuple) != len(self.keys):
+                raise ValueError("tuples must have the same size as TaskBalance.keys")
+
+            matching_weight = 1.0  # default weight
+            matching_best = 0
+            for weight_tuple, (weight, priority) in self._weight_rules.items():
+                p = _get_tuples_matching_power(weight_tuple, needed_tuple)
+                p *= 1 + priority * len(self.keys)
+                if p > matching_best:
+                    matching_weight = weight
+                    matching_best = p
+                elif p == matching_best and p != 0:
+                    raise ValueError("Ambiguity! Two tuples match with same priority.")
+
+            subchunks_weights.append(matching_weight)
+        return subchunks_weights
+
+    def compute_cumweights(
+        self, tuples: list[tuple[ConditionValue, ...]]
+    ) -> list[float]:
+        """Returns the result of `compute_weights` with a cumulative sum, for easier usage with random.choices.
+
+        Parameters
+        ----------
+        tuples : list[tuple[ConditionValue]]
+            List of conditions, e.g. [('DIHARD', 0), ('AMI', 1), ('DIHARD', 1)]
+
+        Returns
+        -------
+        list[float]
+            List of cumulative weights, one per condition.
+            e.g. [1.0, 4.0, 5.0] (obtained from non cumulative weights [1.0, 3.0, 1.0])
+        """
+        subchunks_weights = self.compute_weights(tuples)
+        return list(itertools.accumulate(subchunks_weights))
+
+    @property
+    def keys(self):
+        return self._keys

--- a/tests/test_speechbrain.py
+++ b/tests/test_speechbrain.py
@@ -1,4 +1,5 @@
 import tempfile
+
 import pytest
 from speechbrain.inference import EncoderClassifier
 
@@ -7,14 +8,15 @@ from speechbrain.inference import EncoderClassifier
 def cache():
     return tempfile.mkdtemp()
 
+
 def test_import_speechbrain_encoder_classifier(cache):
     """This is a simple test that check if speechbrain
     EncoderClassifier can be imported. It does not check
-    if the model is working properly. 
+    if the model is working properly.
     """
 
     model = EncoderClassifier.from_hparams(
-        source="speechbrain/spkrec-ecapa-voxceleb", 
+        source="speechbrain/spkrec-ecapa-voxceleb",
         savedir=cache,
     )
     assert isinstance(model, EncoderClassifier)

--- a/tests/utils/test_balance.py
+++ b/tests/utils/test_balance.py
@@ -1,0 +1,67 @@
+import pytest
+
+from pyannote.audio.utils.balance import TaskBalancingSpecifications
+
+
+def test_task_balancing_specifications_simple():
+    rules = {
+        "DB1": 2.0,
+        "DB2": 4.0,
+    }
+    specs1 = TaskBalancingSpecifications(
+        ["database"],
+        weighting_rules=rules,
+    )
+    tuples = [("DB1",), ("DB2",), ("DB3",)]
+    assert specs1.compute_weights(tuples) == [2.0, 4.0, 1.0]
+
+    specs2 = TaskBalancingSpecifications(
+        ["database"],
+    )
+    for tuple, weight in rules.items():
+        specs2.add_weighting_rule(tuple, weight)
+
+    assert specs1.compute_weights(tuples) == specs2.compute_weights(tuples)
+
+
+def test_task_balancing_specifications_advanced():
+    rules = {
+        ("DB1"): 2.0,
+        ("DB2", "train", None): 4.0,
+        (None, "train", "SPK1"): (8.0, 2),
+    }
+    specs1 = TaskBalancingSpecifications(
+        ["database", "subset", "speaker"],
+        weighting_rules=rules,
+    )
+    tuples = [
+        ("DB1", "train", "SPK2"),
+        ("DB2", "train", "SPK1"),
+        ("DB2", "train", "SPK2"),
+        ("DB3", "train", "SPK2"),
+    ]
+    assert specs1.compute_weights(tuples) == [2.0, 8.0, 4.0, 1.0]
+
+
+def test_task_balancing_specifications_ambiguous():
+    rules1 = {
+        ("DB1", "train", None): 4.0,
+        (None, "train", "SPK1"): 8.0,
+    }
+    specs1 = TaskBalancingSpecifications(
+        ["database", "subset", "speaker"],
+        weighting_rules=rules1,
+    )
+    with pytest.raises(ValueError):
+        specs1.compute_weights([("DB1", "train", "SPK1")])
+
+    # now with priority there shouldn't be any ambiguity left
+    rules2 = {
+        ("DB1", "train", None): (4.0, 2),
+        (None, "train", "SPK1"): 8.0,
+    }
+    specs2 = TaskBalancingSpecifications(
+        ["database", "subset", "speaker"],
+        weighting_rules=rules2,
+    )
+    assert specs2.compute_weights([("DB1", "train", "SPK1")]) == [4.0]


### PR DESCRIPTION
The `balance` option of the segmentation tasks allows to pass a list of `ProtocolFile` fields, e.g. `['database', 'foo']`. Then when batches are sampled, it looks at all existing combinations of values for these fields in the task protocol. 

For example if they come from databases `aishell` and `ami`, and their `foo` field is either `a` or `b`, we compute the cartesian product `[('aishell', 'a'), ('aishell', 'b'), ('ami', 'a'), ('ami', 'b')]`, batches are created by randomly selecting one of these tuples and picking a sample from a matching file.

The PR allows to weight the random choice from the cartesian product. For example with 
```python
balance_weights = {
  ('aishell'):2.0,
  ('ami', 'b'): 4.0,
}
```
we will sample from the cartesian product using [random.choices](https://docs.python.org/3/library/random.html#random.choices) with these weights:
```python
selected = random.choices(
    population=[('aishell', 'a'), ('aishell', 'b'), ('ami', 'a'), ('ami', 'b')],
    weights=[2.0, 2.0, 1.0, 4.0],
    k=1,
)[0]
```

e.g. for each tuple of the cartesian product, we find the longest matching (tuple) prefix in `balance_weights` and use this weight.

I'm not sure this approach is flexible/clean enough to be PR-ready, and it's hard to make the docstring concise, but i think it could be really useful :)