### PR TITLE
fix(task): fix estimation of training set size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - fix(task): fix random generators
+- fix(task): fix estimation of training set size
 
 ### Improvements
 

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -255,8 +255,11 @@ class SegmentationTask(Task):
 
     def train__len__(self):
         # Number of training samples in one epoch
+        train_file_ids = np.where(
+            self.prepared_data["audio-metadata"]["subset"] == Subsets.index("train")
+        )[0]
 
-        duration = np.sum(self.prepared_data["audio-annotated"])
+        duration = np.sum(self.prepared_data["audio-annotated"][train_file_ids])
         return max(self.batch_size, math.ceil(duration / self.duration))
 
     def prepare_validation(self, prepared_data: Dict):


### PR DESCRIPTION
Fixes the incorrect implementation of `train__len__` introduced in 7121a73f08ec89d8293a8d95145e623675abbe21 (i think).
 
This error makes training epochs contain `(annotated_duration_train + annotated_duration_val) / model_duration` samples instead of `(annotated_duration_train) / model_duration` samples.