### PR TITLE
Fix seeding in `create_rng_for_worker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
-- fix(task): fix random generators
+- fix(task): fix random generators and their reproducibility
 - fix(task): fix estimation of training set size
 
 ### Improvements

--- a/pyannote/audio/utils/random.py
+++ b/pyannote/audio/utils/random.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 
+import hashlib
 import os
 from random import Random
 
@@ -51,16 +52,18 @@ def create_rng_for_worker(model) -> Random:
     else:
         worker_id = worker_info.id
 
-    seed = hash(
-        (
-            global_seed,
-            worker_id,
-            model.local_rank,
-            model.global_rank,
-            model.current_epoch,
-        )
+    t = (
+        global_seed,
+        worker_id,
+        model.local_rank,
+        model.global_rank,
+        model.current_epoch,
     )
-
+    # use md5 because python's `hash` is not deterministic
+    seed = int.from_bytes(
+        hashlib.md5(str(t).encode(), usedforsecurity=False).digest(),
+        byteorder="big",
+    )
     rng.seed(seed)
 
     return rng

--- a/pyannote/audio/utils/random.py
+++ b/pyannote/audio/utils/random.py
@@ -21,8 +21,8 @@
 # SOFTWARE.
 
 
-import hashlib
 import os
+import zlib
 from random import Random
 
 import torch
@@ -52,18 +52,15 @@ def create_rng_for_worker(model) -> Random:
     else:
         worker_id = worker_info.id
 
-    t = (
+    seed_tuple = (
         global_seed,
         worker_id,
         model.local_rank,
         model.global_rank,
         model.current_epoch,
     )
-    # use md5 because python's `hash` is not deterministic
-    seed = int.from_bytes(
-        hashlib.md5(str(t).encode(), usedforsecurity=False).digest(),
-        byteorder="big",
-    )
+    # use md5 because python's `hash` is not deterministic.
+    seed = zlib.adler32(str(seed_tuple).encode())
     rng.seed(seed)
 
     return rng

--- a/pyannote/audio/utils/random.py
+++ b/pyannote/audio/utils/random.py
@@ -59,7 +59,7 @@ def create_rng_for_worker(model) -> Random:
         model.global_rank,
         model.current_epoch,
     )
-    # use md5 because python's `hash` is not deterministic.
+    # use adler32 because python's `hash` is not deterministic.
     seed = zlib.adler32(str(seed_tuple).encode())
     rng.seed(seed)
 


### PR DESCRIPTION
## The PR
Currently, the seeding in `random.py`'s `create_rng_for_worker` function rely on python's `hash` function. However python's default hashing function is not deterministic between runs.

Since we don't use the hashing for cryptographic purposes, (and although we are not really constrained on execution time either : the function should be called N_WORKERS times at the beginning of each epoch) I opted for the default python implementation of adler32 which should work just fine.

## Some additional notes regarding determinism
From what I have tried, only `seed_everything` (no need to put it before imports) and `Trainer(..., deterministic=True)` are required to make runs fully deterministic.

Not required:
- `torch.use_deterministic_algorithms(True)`: which force using pytorch's slower but deterministic functions
- defining environment variable `PYTHONHASHSEED`. It makes the default `hash()` fn deterministic, but the nondeterminism seems to be there to avoid security issues with collisions, it's best to avoid this approach.