### PR TITLE
doc: fix typo in powerset docstring

### DIFF
--- a/pyannote/audio/utils/powerset.py
+++ b/pyannote/audio/utils/powerset.py
@@ -109,7 +109,7 @@ class Powerset(nn.Module):
             Soft predictions in "powerset" space.
         soft : bool, optional
             Return soft multi-label predictions. Defaults to False (i.e. hard predictions)
-            Assumes that `powerset` are "logits" (not "probabilities").
+            Assumes that `powerset` are "log probabilities" (not "probabilities").
 
         Returns
         -------

--- a/pyannote/audio/utils/powerset.py
+++ b/pyannote/audio/utils/powerset.py
@@ -109,7 +109,7 @@ class Powerset(nn.Module):
             Soft predictions in "powerset" space.
         soft : bool, optional
             Return soft multi-label predictions. Defaults to False (i.e. hard predictions)
-            Assumes that `powerset` are "log probabilities" (not "probabilities").
+            Assumes that `powerset` are "log probabilities".
 
         Returns
         -------


### PR DESCRIPTION
Change description in docstring from "logit" to "log probability" as described in #1703 