### PR TITLE
memory optimizations for pyannote.audio.core.inference.Inference.aggregate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - improve(io): when available, default to using `soundfile` backend
 - improve(pipeline): do not extract embeddings when `max_speakers` is set to 1
+- improve(pipeline): optimize memory usage of most pipelines ([#1713](https://github.com/pyannote/pyannote-audio/pull/1713) by [@benniekiss](https://github.com/benniekiss/))
 
 ## Version 3.2.0 (2024-05-08)
 

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -560,7 +560,7 @@ class Inference(BaseInference):
         )
 
         masks = 1 - np.isnan(scores)
-        scores.data = np.nan_to_num(scores.data, copy=True, nan=0.0)
+        np.nan_to_num(scores.data, copy=False, nan=0.0)
 
         # Hamming window used for overlap-add aggregation
         hamming_window = (

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -559,9 +559,6 @@ class Inference(BaseInference):
             step=frames.step,
         )
 
-        masks = 1 - np.isnan(scores)
-        np.nan_to_num(scores.data, copy=False, nan=0.0)
-
         # Hamming window used for overlap-add aggregation
         hamming_window = (
             np.hamming(num_frames_per_chunk).reshape(-1, 1)
@@ -613,11 +610,13 @@ class Inference(BaseInference):
         )
 
         # loop on the scores of sliding chunks
-        for (chunk, score), (_, mask) in zip(scores, masks):
+        for chunk, score in scores:
             # chunk ~ Segment
             # score ~ (num_frames_per_chunk, num_classes)-shaped np.ndarray
             # mask ~ (num_frames_per_chunk, num_classes)-shaped np.ndarray
-
+            mask = 1 - np.isnan(score)
+            np.nan_to_num(score, copy=False, nan=0.0)
+            
             start_frame = frames.closest_frame(chunk.start + 0.5 * frames.duration)
 
             aggregated_output[start_frame : start_frame + num_frames_per_chunk] += (


### PR DESCRIPTION
While diarizing long audio recordings (>6 hours), I noticed very high memory usage, upwards of 30GB.
I tracked the spike to `pyannote.audio.core.inference.Inference.aggregate()`, which was initializing several very large tensors. 

With this PR, RAM usage is reduced by 10 - 15 GB for long audio files in my tests. I have not tested extensively, but I do not believe this impacts accuracy or speed.

I did have one question related to one of the commits,

> currently, frames is recreated only so that it has the same start as chunks,
> but from my understanding, there are no cases where chunks.start and frames.start
> would be anything other than 0.0.

Is this a correct assumption? Otherwise, frames should be reinitialized. 

Now, the whole speaker diarization pipeline does not peak past 20GB of RAM for a 9hr recording. this is constrained by both `Inference.aggregate` and `scipy.cluster.hierarchy.linkage` in the AgglomerativeClustering pipeline.