### PR TITLE
Fix validation preparation issue when a protocol does not define a development set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - fix(task): fix wrong train/development split when training with (some) meta-protocols ([#1709](https://github.com/pyannote/pyannote-audio/issues/1709))
+- fix(task): fix metadata preparation with missing validation subset ([@clement-pages](https://github.com/clement-pages/))
 
 ### Improvements
 

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -595,7 +595,9 @@ class Task(pl.LightningDataModule):
         prepared_data["metadata-labels"] = np.array(unique_labels, dtype=np.str_)
         unique_labels.clear()
 
-        self.prepare_validation(prepared_data)
+        if self.has_validation:
+            self.prepare_validation(prepared_data)
+
         self.post_prepare_data(prepared_data)
 
         # save prepared data on the disk


### PR DESCRIPTION
When using the following protocol, with no development subset defined : 
```yml
EmbeddingsTaskOnlyMini:
    train:
        VoxCeleb.SpeakerVerification.VoxCelebMini: [train, ]
    development:
        # no development subset defined
```
I encountered this  error:

```
Traceback (most recent call last):
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/eend_2/joint/test_train.py", line 40, in <module>
    trainer.fit(model)
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 544, in fit
    call._call_and_handle_interrupt(
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/call.py", line 44, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 580, in _fit_impl
    self._run(model, ckpt_path=ckpt_path)
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 941, in _run
    self._data_connector.prepare_data()
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/connectors/data_connector.py", line 100, in prepare_data
    call._call_lightning_module_hook(trainer, "prepare_data")
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/micromamba/envs/pyannote/lib/python3.9/site-packages/pytorch_lightning/trainer/call.py", line 157, in _call_lightning_module_hook
    output = fn(*args, **kwargs)
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/pyannote-audio/pyannote/audio/core/model.py", line 198, in prepare_data
    self.task.prepare_data()
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/pyannote-audio/pyannote/audio/core/task.py", line 596, in prepare_data
    self.prepare_validation(prepared_data)
  File "/gpfsdswork/projects/rech/bvr/uaf83xi/pyannote-audio/pyannote/audio/tasks/segmentation/mixins.py", line 293, in prepare_validation
    get_dtype(max(v[0] for v in validation_chunks)),
ValueError: max() arg is an empty sequence
```

This PR fixes the issue.