### PR TITLE
Doc: fix partially removed docstring

### DIFF
--- a/pyannote/audio/core/pipeline.py
+++ b/pyannote/audio/core/pipeline.py
@@ -69,7 +69,8 @@ class Pipeline(_Pipeline):
             to True or to a string containing your hugginface.co authentication
             token that can be obtained by running `huggingface-cli login`
         cache_dir: Path or str, optional
-            Path to model cache directory. Defauorch/pyannote" when unset.
+            Path to model cache directory. Defaults to content of PYANNOTE_CACHE
+            environment variable, or "~/.cache/torch/pyannote" when unset.
         """
 
         checkpoint_path = str(checkpoint_path)


### PR DESCRIPTION
Part of the  `cache_dir` argument part of the  `Pipeline` class docstring was removed in a [commit](https://github.com/pyannote/pyannote-audio/commit/78df4890f855bcde94735a7bb8fe31a7234b8ac6) resulting in an incorrect and confusing sentence.
This PR restores the original description of the parameter.