### PR TITLE
Update pyannote-audio installation version number

### DIFF
--- a/tutorials/community/eval_separation_pipeline.ipynb
+++ b/tutorials/community/eval_separation_pipeline.ipynb
@@ -66,7 +66,7 @@
         "!pip install -qq speechbrain==0.5.16\n",
         "!pip install -qq ipython==7.34.0\n",
         "!pip install -qq ipywidgets openai-whisper whisperx==3.1.5 meeteval\n",
-        "!pip install -qq pyannote.audio[separation]"
+        "!pip install -qq pyannote.audio[separation]==3.3.0"
       ]
     },
     {


### PR DESCRIPTION
For separation, it require the pyannote-audio may be atleast pyannote-audio==3.3.0