### PR TITLE
Alignment of separation output and diarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixes
 
 - fix: fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
-- fix: fix alignment between separated sources and diarization when the diarization reference is available
+- fix: fix alignment between separated sources and diarization when the diarization reference is available ([@Lebourdais](https://github.com/Lebourdais/))
 
 ## Version 3.3.2 (2024-09-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - fix: fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
+- fix: fix alignment between separated sources and diarization when the diarization reference is available
 
 ## Version 3.3.2 (2024-09-11)
 

--- a/pyannote/audio/pipelines/speech_separation.py
+++ b/pyannote/audio/pipelines/speech_separation.py
@@ -726,7 +726,6 @@ class SpeechSeparation(SpeakerDiarizationMixin, Pipeline):
 
         # re-order centroids so that they match
         # the order given by diarization.labels()
-        inverse_mapping = {label: index for index, label in mapping.items()}
         centroids = centroids[
             [inverse_mapping[label] for label in diarization.labels()]
         ]

--- a/pyannote/audio/pipelines/speech_separation.py
+++ b/pyannote/audio/pipelines/speech_separation.py
@@ -124,7 +124,7 @@ class SpeechSeparation(SpeakerDiarizationMixin, Pipeline):
 
     def __init__(
         self,
-        segmentation: PipelineModel = None,
+        segmentation: PipelineModel = "pyannote/separation-ami-1.0",
         segmentation_step: float = 0.1,
         embedding: PipelineModel = "speechbrain/spkrec-ecapa-voxceleb@5c0be3875fda05e81f3c004ed8c7c06be308de1e",
         embedding_exclude_overlap: bool = False,
@@ -697,6 +697,15 @@ class SpeechSeparation(SpeakerDiarizationMixin, Pipeline):
         # at this point, `diarization` speaker labels are strings (or mix of
         # strings and integers when reference is available and some hypothesis
         # speakers are not present in the reference)
+
+        # re-order sources so that they match
+        # the order given by diarization.labels()
+        inverse_mapping = {label: index for index, label in mapping.items()}
+        original_sliding_window = sources.sliding_window
+        data = sources.data[
+            :, [inverse_mapping[label] for label in diarization.labels()]
+        ]
+        sources = SlidingWindowFeature(data, original_sliding_window)
 
         if not return_embeddings:
             return diarization, sources

--- a/pyannote/audio/pipelines/speech_separation.py
+++ b/pyannote/audio/pipelines/speech_separation.py
@@ -701,11 +701,9 @@ class SpeechSeparation(SpeakerDiarizationMixin, Pipeline):
         # re-order sources so that they match
         # the order given by diarization.labels()
         inverse_mapping = {label: index for index, label in mapping.items()}
-        original_sliding_window = sources.sliding_window
-        data = sources.data[
+        source.data = sources.data[
             :, [inverse_mapping[label] for label in diarization.labels()]
         ]
-        sources = SlidingWindowFeature(data, original_sliding_window)
 
         if not return_embeddings:
             return diarization, sources


### PR DESCRIPTION
Fix of the alignment between the separated sources and the diarization output.
The issue only occurred when using an "annotation" key to the file to give a reference.
The diarization was then permutated without permutating the associated sources.

