### PR TITLE
Remove pytorch_metric_learning dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pyannote.core >= 5.0.0
 pyannote.database >= 5.0.1
 pyannote.metrics >= 3.2
 pyannote.pipeline >= 3.0.1
-pytorch_metric_learning >= 2.1.0
 rich >= 12.0.0
 semver >= 3.0.0
 soundfile >= 0.12.1


### PR DESCRIPTION
pytorch-metric-learning has this numpy requirement that makes it hard to work with other package needing numpy > 2.0.

https://github.com/KevinMusgrave/pytorch-metric-learning/blob/master/setup.py#L42

Given the uses of pytorch-metric-learning in pyannote, which is only `ArcFaceLoss`, isn't it better to simply remove the pytorch-metric-learning deps and have 100 more line of code ?

Given the complexity of pytorch-metric-learning (lots of mixins), I came up with this version which I think is similar.
Testing code:
```py
torch.manual_seed(0)
num_classes = 2
embedding_size = 10
margin = 0.3
scale = 1
batch_size = 5
embeddings = torch.randn(batch_size, embedding_size)
labels = torch.randint(0, num_classes, (batch_size,))

af_own = ArcFaceLoss(num_classes, embedding_size, margin, scale)
loss = af_own.forward(embeddings, labels)
print(loss)

from pytorch_metric_learning.losses import ArcFaceLoss as afpytml
af = afpytml(
    num_classes, embedding_size, margin, scale
)
af.W = af_own.W
loss = af.forward(embeddings, labels)
print(loss)
```
I did not retrained a model to fully verify.