### PR TITLE
Fix balance

### DIFF
--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -632,6 +632,7 @@ class Task(pl.LightningDataModule):
         try:
             with open(self.cache, "rb") as cache_file:
                 self.prepared_data = dict(np.load(cache_file, allow_pickle=True))
+                self.prepared_data["metadata-values"] = self.prepared_data["metadata-values"].item()
         except FileNotFoundError:
             print(
                 "Cached data for protocol not found. Ensure that prepare_data() was called",


### PR DESCRIPTION
Fixes
1. the new `prepare_data` implementation (which allows caching to file) changes how things are stored. The PR did not update `[self.prepared_data["metadata"]` -> `[self.prepared_data["metadata-values"]` in the segmentation mixin.
2. when the combination of balanced key do not exist. For example when we have `balance=['database','domain']`), the implementation creates one sample generator for each possible combination (`itertools.product` of all values), but of course some combinations might not exist. To fix this, if the generator cannot produce anything, it returns a None as its first and only value (there might be a cleaner way).

I don't have time to really test but it should fix https://github.com/nttcslab-sp/mamba-diarization/issues/6 !

EDIT: might or might not work with pyannote's latest versions, needs testing