### PR TITLE
update weights optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,18 @@ Clipping and speaker/source alignment issues in speech separation pipeline have 
 - feat(utils): add `hidden` option to `ProgressHook`
 - feat(utils): add `FilterByNumberOfSpeakers` protocol files filter
 
+### Improvements
+
+- improve(model): improve WavLM (un)freezing support for `SSeRiouSS` architectures ([@clement-pages](https://github.com/clement-pages/))
+- improve(task): improve `SpeakerDiarization` training with manual optimization ([@clement-pages](https://github.com/clement-pages/))
+
 ### Fixes
 
+- fix(model): improve WavLM (un)freezing support for `ToTaToNet` architectures ([@clement-pages](https://github.com/clement-pages/))
 - fix(separation): fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
 - fix(separation): fix alignment between separated sources and diarization ([@Lebourdais](https://github.com/Lebourdais/) and [@clement-pages](https://github.com/clement-pages/))
 - fix(separation): prevent leakage removal collar from being applied to diarization ([@clement-pages](https://github.com/clement-pages/))
+- fix(separation): fix `PixIT` training with manual optimization ([@clement-pages](https://github.com/clement-pages/))
 - fix(doc): fix link to pytorch ([@emmanuel-ferdman](https://github.com/emmanuel-ferdman/))
 - fix(task): fix corner case with small (<9) number of validation samples ([@antoinelaurent](https://github.com/antoinelaurent/))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
 
 ### Fixes
 
-- fix: fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
-- fix: fix alignment between separated sources and diarization when the diarization reference is available ([@Lebourdais](https://github.com/Lebourdais/))
+- fix(separation): fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
+- fix(separation): fix alignment between separated sources and diarization ([@Lebourdais](https://github.com/Lebourdais/) and [@clement-pages](https://github.com/clement-pages/))
 - fix(doc): fix link to pytorch ([@emmanuel-ferdman](https://github.com/emmanuel-ferdman/))
 
 ## Version 3.3.2 (2024-09-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,12 @@ Clipping and speaker/source alignment issues in speech separation pipeline have 
 
 ### Improvements
 
-- improve(model): improve WavLM (un)freezing support for `SSeRiouSS` architectures ([@clement-pages](https://github.com/clement-pages/))
+- improve(model): improve WavLM (un)freezing support for `SSeRiouSS` architecture ([@clement-pages](https://github.com/clement-pages/))
 - improve(task): improve `SpeakerDiarization` training with manual optimization ([@clement-pages](https://github.com/clement-pages/))
 
 ### Fixes
 
-- fix(model): improve WavLM (un)freezing support for `ToTaToNet` architectures ([@clement-pages](https://github.com/clement-pages/))
+- fix(model): improve WavLM (un)freezing support for `ToTaToNet` architecture ([@clement-pages](https://github.com/clement-pages/))
 - fix(separation): fix clipping issue in speech separation pipeline ([@joonaskalda](https://github.com/joonaskalda/))
 - fix(separation): fix alignment between separated sources and diarization ([@Lebourdais](https://github.com/Lebourdais/) and [@clement-pages](https://github.com/clement-pages/))
 - fix(separation): prevent leakage removal collar from being applied to diarization ([@clement-pages](https://github.com/clement-pages/))

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -650,6 +650,10 @@ class Task(pl.LightningDataModule):
     def automatic_optimization(self) -> bool:
         return self.model.automatic_optimization
 
+    @automatic_optimization.setter
+    def automatic_optimization(self, automatic_optimisation: bool) -> None:
+        self.model.automatic_optimization = automatic_optimisation
+
     @property
     def specifications(self) -> Union[Specifications, Tuple[Specifications]]:
         # setup metadata on-demand the first time specifications are requested and missing

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -647,6 +647,10 @@ class Task(pl.LightningDataModule):
             )
 
     @property
+    def automatic_optimization(self) -> bool:
+        return self.model.automatic_optimization
+
+    @property
     def specifications(self) -> Union[Specifications, Tuple[Specifications]]:
         # setup metadata on-demand the first time specifications are requested and missing
         if not hasattr(self, "_specifications"):

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -467,6 +467,9 @@ class SpeakerDiarization(SegmentationTask):
 
         if not self.automatic_optimization:
             optimizers = self.model.optimizers()
+            optimizers = (
+                [optimizers] if not isinstance(optimizers, list) else optimizers
+            )
             for optimizer in optimizers:
                 optimizer.zero_grad()
 
@@ -668,4 +671,5 @@ def evaluate(protocol: str, subset: str = "test", model: str = "pyannote/segment
 
 if __name__ == "__main__":
     import typer
+
     typer.run(evaluate)

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -467,9 +467,7 @@ class SpeakerDiarization(SegmentationTask):
 
         if not self.automatic_optimization:
             optimizers = self.model.optimizers()
-            optimizers = (
-                [optimizers] if not isinstance(optimizers, list) else optimizers
-            )
+            optimizers = optimizers if isinstance(optimizers, list) else [optimizers]
             for optimizer in optimizers:
                 optimizer.zero_grad()
 

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -398,10 +398,6 @@ class SpeakerDiarization(SegmentationTask):
 
         return torch.from_numpy(np.stack(collated_y))
 
-    @property
-    def automatic_optimization(self):
-        return self.model.automatic_optimization
-
     def training_step(self, batch, batch_idx: int):
         """Compute permutation-invariant segmentation loss
 
@@ -469,7 +465,7 @@ class SpeakerDiarization(SegmentationTask):
             logger=True,
         )
 
-        if not self.model.automatic_optimization:
+        if not self.automatic_optimization:
             optimizers = self.model.optimizers()
             for optimizer in optimizers:
                 optimizer.zero_grad()

--- a/pyannote/audio/tasks/separation/PixIT.py
+++ b/pyannote/audio/tasks/separation/PixIT.py
@@ -1012,9 +1012,7 @@ class PixIT(SegmentationTask):
         # using multiple optimizers requires manual optimization
         if not self.automatic_optimization:
             optimizers = self.model.optimizers()
-            optimizers = (
-                [optimizers] if not isinstance(optimizers, list) else optimizers
-            )
+            optimizers = optimizers if isinstance(optimizers, list) else [optimizers]
             for optimizer in optimizers:
                 optimizer.zero_grad()
 

--- a/pyannote/audio/tasks/separation/PixIT.py
+++ b/pyannote/audio/tasks/separation/PixIT.py
@@ -1012,6 +1012,9 @@ class PixIT(SegmentationTask):
         # using multiple optimizers requires manual optimization
         if not self.automatic_optimization:
             optimizers = self.model.optimizers()
+            optimizers = (
+                [optimizers] if not isinstance(optimizers, list) else optimizers
+            )
             for optimizer in optimizers:
                 optimizer.zero_grad()
 


### PR DESCRIPTION
BREAKING: remove `finetune_wavlm` attributes from the `PixIT` task, and replace it with `walm_frozen` in `Totatonet` separation model, to be consistent with what is done for the segmentation model.