### PR TITLE
set wavlm mode to `train` in both `totatonet` and `sseriouss`

### DIFF
--- a/pyannote/audio/models/segmentation/SSeRiouSS.py
+++ b/pyannote/audio/models/segmentation/SSeRiouSS.py
@@ -128,6 +128,9 @@ class SSeRiouSS(Model):
                 data=torch.ones(wav2vec_num_layers), requires_grad=True
             )
         
+        # by default, wa2vec is in eval mode (especially when loading from torchaudio)
+        self.wav2vec.train()
+
         for param in self.wav2vec.parameters():
             param.requires_grad = not wav2vec_frozen
 

--- a/pyannote/audio/models/separation/ToTaToNet.py
+++ b/pyannote/audio/models/separation/ToTaToNet.py
@@ -178,6 +178,8 @@ class ToTaToNet(Model):
 
         if self.use_wavlm:
             self.wavlm = AutoModel.from_pretrained("microsoft/wavlm-large")
+            # by default wavlm is in eval mode
+            self.wavlm.train()
             for param in self.wavlm.parameters():
                 param.requires_grad = not wavlm_frozen
             downsampling_factor = 1


### PR DESCRIPTION
By default, wavlm (more exactly wav2vec module for `sseriouss`) is in `eval` mode in both these architectures, disabling dropout for example (#1793).

For `wav2vec` (used in `sseriouss`), wavlm was set in `eval` mode in [this](https://github.com/pytorch/audio/pull/1843) `torchaudio` PR.