### PR TITLE
Fix incorrect type hint

### DIFF
--- a/pyannote/audio/core/pipeline.py
+++ b/pyannote/audio/core/pipeline.py
@@ -98,7 +98,7 @@ class Pipeline(_Pipeline):
         hparams_file: Union[Text, Path] = None,
         use_auth_token: Union[Text, None] = None,
         cache_dir: Union[Path, Text] = CACHE_DIR,
-    ) -> "Pipeline":
+    ) -> "Pipeline" | None:
         """Load pretrained pipeline
 
         Parameters


### PR DESCRIPTION
`Pipeline.from_pretrained` can actually return `None` (see line 158).