### PR TITLE
fix: update pipeline parameters in speech separation tutorial

### DIFF
--- a/tutorials/community/eval_separation_pipeline.ipynb
+++ b/tutorials/community/eval_separation_pipeline.ipynb
@@ -590,10 +590,10 @@
       "source": [
         "pipeline.instantiate(\n",
         "    {\n",
-        "        \"segmentation\": {\"min_duration_off\": 0.0, \"threshold\": 0.82},\n",
+        "        \"segmentation\": {\"min_duration_off\": 0.0, \"threshold\": 0.5},\n",
         "        \"clustering\": {\n",
         "            \"method\": \"centroid\",\n",
-        "            \"min_cluster_size\": 15,\n",
+        "            \"min_cluster_size\": 50,\n",
         "            \"threshold\": 0.68,\n",
         "        },\n",
         "        \"separation\": {\n",


### PR DESCRIPTION
This PR updates the speech separation pipeline parameters in the evaluation tutorial. The previous parameters were optimized for a different cpWER definition while the new ones are optimized for MeetEval's definition which is also the one used in the tutorial. For more details see Appendix A in v2 of [the PixIT paper](https://arxiv.org/abs/2403.02288).