### PR TITLE
fix(audio): prevent typerror in crop error handling

### DIFF
--- a/src/pyannote/audio/core/io.py
+++ b/src/pyannote/audio/core/io.py
@@ -398,10 +398,16 @@ class Audio:
 
         if mode == "raise":
             if num_frames > frames:
-                raise ValueError(
-                    f"requested fixed duration ({duration:6f}s, or {num_frames:d} frames) is longer "
-                    f"than file duration ({frames / sample_rate:.6f}s, or {frames:d} frames)."
-                )
+                if duration is not None:
+                    raise ValueError(
+                        f"requested fixed duration ({duration:.6f}s, or {num_frames:d} frames) is longer "
+                        f"than file duration ({frames / sample_rate:.6f}s, or {frames:d} frames)."
+                    )
+                else:
+                    raise ValueError(
+                        f"requested chunk duration ({segment.duration:.6f}s, or {num_frames:d} frames) is longer "
+                        f"than file duration ({frames / sample_rate:.6f}s, or {frames:d} frames)."
+                    )
 
             if end_frame > frames + math.ceil(self.PRECISION * sample_rate):
                 raise ValueError(


### PR DESCRIPTION
This happens when the duration parameter passed to crop is None. The subsequent error handling attempts to format this None value as a float within an f-string, causing the TypeError and masking the original out-of-bounds error.