### PR TITLE
Fix: cast np.float32 to float in audio crop and pad tensors in collate_X to avoid size mismatches

### DIFF
--- a/src/pyannote/audio/core/io.py
+++ b/src/pyannote/audio/core/io.py
@@ -389,10 +389,11 @@ class Audio:
             metadata.duration_seconds_from_header, sample_rate
         )
 
-        start: float = segment.start
-        end: float = segment.end
+        # convert to float to avoid issues with np.float32 rounding errors when training
+        start: float = float(segment.start)
+        end: float = float(segment.end)
 
-        pad_start: int = max(0, self.get_num_samples(-segment.start, sample_rate))
+        pad_start: int = max(0, self.get_num_samples(-start, sample_rate))
         if start < 0:
             if mode == "raise":
                 raise ValueError(
@@ -402,7 +403,7 @@ class Audio:
                 start = 0.0
 
         pad_end: int = (
-            max(self.get_num_samples(segment.end, sample_rate), num_samples)
+            max(self.get_num_samples(end, sample_rate), num_samples)
             - num_samples
         )
         if end > duration:
@@ -414,7 +415,7 @@ class Audio:
             else:
                 end = duration
 
-        samples: AudioSamples = decoder.get_samples_played_in_range(float(start), float(end))
+        samples: AudioSamples = decoder.get_samples_played_in_range(start, end)
         data = samples.data
         sample_rate = samples.sample_rate
 

--- a/src/pyannote/audio/core/io.py
+++ b/src/pyannote/audio/core/io.py
@@ -414,7 +414,7 @@ class Audio:
             else:
                 end = duration
 
-        samples: AudioSamples = decoder.get_samples_played_in_range(start, end)
+        samples: AudioSamples = decoder.get_samples_played_in_range(float(start), float(end))
         data = samples.data
         sample_rate = samples.sample_rate
 

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -181,8 +181,6 @@ class SegmentationTask(Task):
             # generate random chunk
             yield next(chunks)
 
-    #def collate_X(self, batch) -> torch.Tensor:
-    #    return default_collate([b["X"] for b in batch])
 
     def collate_X(self, batch) -> torch.Tensor:
         xs = [b["X"] for b in batch]


### PR DESCRIPTION
- Cast np.float32 to Python float in audio cropping
Ensures decoder.get_samples_played_in_range(start, end) behaves consistently.
Prevents mismatches between expected_num_samples and samples.data.shape caused by rounding differences.

- Pad tensors in collate_X
Adds zero-padding to all tensors in a batch so they have the same length.
Prevents RuntimeError when default_collate tries to stack tensors of different sizes.