### PR TITLE
PYA-958: provide one rttm per file for OptimizedMinDurationOff when `--per-file` is set.

### DIFF
--- a/src/pyannote/audio/__main__.py
+++ b/src/pyannote/audio/__main__.py
@@ -790,8 +790,21 @@ def benchmark(
             yaml.dump({"min_duration_off": best_min_duration_off}, yml)
 
         # save output in RTTM format
-        with open(into / f"{benchmark_name}.OptimizedMinDurationOff.rttm", "w") as rttm:
-            for file in files:
+        if per_file:
+            optimized_rttm_dir = benchmark_dir / "rttm_OptimizedMinDurationOff"
+            optimized_rttm_dir.mkdir()
+        else:
+            optimized_rttm_file = into / f"{benchmark_name}.OptimizedMinDurationOff.rttm"
+            
+            # make suire we don't overwrite previous results
+            if optimized_rttm_file.exists():
+                raise FileExistsError(f"{optimized_rttm_file} already exists.")
+        
+        for file in files:
+            if per_file:
+                optimized_rttm_file = optimized_rttm_dir / f"{file['uri']}_OptimizedMinDurationOff.rttm"
+  
+            with open(optimized_rttm_file, "w" if per_file else "a") as rttm:
                 file["best_speaker_diarization"].write_rttm(rttm)
 
 


### PR DESCRIPTION
Do the same as for other rttm files, for consistency when `--per-file` is set