### PR TITLE
Add validate_chunk flag (reorganized and updated)

### DIFF
--- a/src/pyannote/audio/core/task.py
+++ b/src/pyannote/audio/core/task.py
@@ -519,7 +519,7 @@ class Task(lightning.LightningDataModule):
 
         # since not all metadata keys are present in all files, fallback to -1 when a key is missing
         metadata = [
-            tuple(metadatum.get(key, -1) for key in metadata_unique_values)
+            tuple(metadatum.get(key, -1) for key in metadata_unique_values) # only the keys in metadata_unique_values got transmitted!!!
             for metadatum in metadata
         ]
         metadata_dtype = [

--- a/src/pyannote/audio/core/task.py
+++ b/src/pyannote/audio/core/task.py
@@ -519,7 +519,7 @@ class Task(lightning.LightningDataModule):
 
         # since not all metadata keys are present in all files, fallback to -1 when a key is missing
         metadata = [
-            tuple(metadatum.get(key, -1) for key in metadata_unique_values) # only the keys in metadata_unique_values got transmitted!!!
+            tuple(metadatum.get(key, -1) for key in metadata_unique_values)
             for metadatum in metadata
         ]
         metadata_dtype = [

--- a/src/pyannote/audio/core/task.py
+++ b/src/pyannote/audio/core/task.py
@@ -331,7 +331,6 @@ class Task(lightning.LightningDataModule):
         }
 
         """
-
         if self.cache:
             # check if cache exists and is not empty:
             if self.cache.exists() and self.cache.stat().st_size > 0:
@@ -343,7 +342,7 @@ class Task(lightning.LightningDataModule):
             # if no cache was provided by user, create a temporary file
             # in system directory used for temp files
             self.cache = Path(mkstemp()[1])
-
+        
         # list of possible values for each metadata key
         # (will become .prepared_data[""])
         metadata_unique_values = defaultdict(list)
@@ -417,6 +416,8 @@ class Task(lightning.LightningDataModule):
                     metadatum[key] = metadata_unique_values[key].index(value)
 
                 elif isinstance(value, int):
+                    if value not in metadata_unique_values[key]:
+                        metadata_unique_values[key].append(value)
                     metadatum[key] = value
 
                 else:
@@ -548,13 +549,12 @@ class Task(lightning.LightningDataModule):
             ("database_label_idx", get_dtype(max(a[4] for a in annotations))),
             ("global_label_idx", get_dtype(max(a[5] for a in annotations))),
         ]
-
+        
         # save all protocol data in a dict
         prepared_data = {}
-
         # keep track of protocol name
         prepared_data["protocol"] = self.protocol.name
-
+        
         prepared_data["audio-path"] = np.array(audios, dtype=np.str_)
         audios.clear()
 
@@ -568,7 +568,7 @@ class Task(lightning.LightningDataModule):
             annotated_regions, dtype=region_dtype
         )
         annotated_regions.clear()
-
+        
         prepared_data["audio-regions-ids"] = np.array(
             audio_regions_ids, dtype=[("start", "i"), ("end", "i")]
         )
@@ -585,7 +585,7 @@ class Task(lightning.LightningDataModule):
         audio_segments_ids.clear()
 
         prepared_data["metadata-values"] = metadata_unique_values
-
+        
         for database, labels in database_unique_labels.items():
             prepared_data[f"metadata-{database}-labels"] = np.array(
                 labels, dtype=np.str_
@@ -594,12 +594,12 @@ class Task(lightning.LightningDataModule):
 
         prepared_data["metadata-labels"] = np.array(unique_labels, dtype=np.str_)
         unique_labels.clear()
-
+        
         if self.has_validation:
             self.prepare_validation(prepared_data)
 
         self.post_prepare_data(prepared_data)
-
+        
         # save prepared data on the disk
         with open(self.cache, "wb") as cache_file:
             np.savez_compressed(cache_file, **prepared_data)

--- a/src/pyannote/audio/core/task.py
+++ b/src/pyannote/audio/core/task.py
@@ -331,6 +331,7 @@ class Task(lightning.LightningDataModule):
         }
 
         """
+
         if self.cache:
             # check if cache exists and is not empty:
             if self.cache.exists() and self.cache.stat().st_size > 0:
@@ -342,7 +343,7 @@ class Task(lightning.LightningDataModule):
             # if no cache was provided by user, create a temporary file
             # in system directory used for temp files
             self.cache = Path(mkstemp()[1])
-        
+
         # list of possible values for each metadata key
         # (will become .prepared_data[""])
         metadata_unique_values = defaultdict(list)
@@ -416,8 +417,6 @@ class Task(lightning.LightningDataModule):
                     metadatum[key] = metadata_unique_values[key].index(value)
 
                 elif isinstance(value, int):
-                    if value not in metadata_unique_values[key]:
-                        metadata_unique_values[key].append(value)
                     metadatum[key] = value
 
                 else:
@@ -549,12 +548,13 @@ class Task(lightning.LightningDataModule):
             ("database_label_idx", get_dtype(max(a[4] for a in annotations))),
             ("global_label_idx", get_dtype(max(a[5] for a in annotations))),
         ]
-        
+
         # save all protocol data in a dict
         prepared_data = {}
+
         # keep track of protocol name
         prepared_data["protocol"] = self.protocol.name
-        
+
         prepared_data["audio-path"] = np.array(audios, dtype=np.str_)
         audios.clear()
 
@@ -568,7 +568,7 @@ class Task(lightning.LightningDataModule):
             annotated_regions, dtype=region_dtype
         )
         annotated_regions.clear()
-        
+
         prepared_data["audio-regions-ids"] = np.array(
             audio_regions_ids, dtype=[("start", "i"), ("end", "i")]
         )
@@ -585,7 +585,7 @@ class Task(lightning.LightningDataModule):
         audio_segments_ids.clear()
 
         prepared_data["metadata-values"] = metadata_unique_values
-        
+
         for database, labels in database_unique_labels.items():
             prepared_data[f"metadata-{database}-labels"] = np.array(
                 labels, dtype=np.str_
@@ -594,12 +594,12 @@ class Task(lightning.LightningDataModule):
 
         prepared_data["metadata-labels"] = np.array(unique_labels, dtype=np.str_)
         unique_labels.clear()
-        
+
         if self.has_validation:
             self.prepare_validation(prepared_data)
 
         self.post_prepare_data(prepared_data)
-        
+
         # save prepared data on the disk
         with open(self.cache, "wb") as cache_file:
             np.savez_compressed(cache_file, **prepared_data)

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -92,6 +92,7 @@ class SegmentationTask(Task):
             training &= self.prepared_data["audio-metadata"][key] == self.prepared_data[
                 "metadata"
             ][key].index(value)
+        file_ids = np.where(training)[0]
 
         # turn annotated duration into a probability distribution
         annotated_duration = self.prepared_data["audio-annotated"][file_ids]

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -92,6 +92,7 @@ class SegmentationTask(Task):
             training &= self.prepared_data["audio-metadata"][key] == self.prepared_data[
                 "metadata"
             ][key].index(value)
+        file_ids = np.where(training)[0]
 
         # turn annotated duration into a probability distribution
         annotated_duration = self.prepared_data["audio-annotated"][file_ids]
@@ -295,7 +296,7 @@ class SegmentationTask(Task):
                     else:
                         validation_chunks.append((file_id, start_time, self.duration))
                     unvalidated_chunks.append((file_id, start_time, self.duration))
-               
+           
         dtype = [
             (
                 "file_id",

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -92,6 +92,7 @@ class SegmentationTask(Task):
             training &= self.prepared_data["audio-metadata"][key] == self.prepared_data[
                 "metadata"
             ][key].index(value)
+        file_ids = np.where(training)[0]
 
         # turn annotated duration into a probability distribution
         annotated_duration = self.prepared_data["audio-annotated"][file_ids]
@@ -290,7 +291,7 @@ class SegmentationTask(Task):
                     else:
                         validation_chunks.append((file_id, start_time, self.duration))
                     unvalidated_chunks.append((file_id, start_time, self.duration))
-               
+           
         dtype = [
             (
                 "file_id",

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -91,6 +91,7 @@ class SegmentationTask(Task):
             training &= self.prepared_data["audio-metadata"][key] == self.prepared_data[
                 "metadata"
             ][key].index(value)
+        file_ids = np.where(training)[0]
 
         # turn annotated duration into a probability distribution
         annotated_duration = self.prepared_data["audio-annotated"][file_ids]
@@ -259,7 +260,8 @@ class SegmentationTask(Task):
 
     def prepare_validation(self, prepared_data: Dict):
         validation_chunks = list()
-
+        unvalidated_chunks = list()
+    
         # obtain indexes of files in the validation subset
         validation_file_ids = np.where(
             prepared_data["audio-metadata"]["subset"] == Subsets.index("development")
@@ -276,34 +278,40 @@ class SegmentationTask(Task):
             for annotated_region in annotated_regions:
                 # number of chunks in annotated region
                 num_chunks = round(annotated_region["duration"] // self.duration)
-
                 # iterate over chunks
                 for c in range(num_chunks):
                     start_time = annotated_region["start"] + c * self.duration
                     ## chunk-level filtering : remove or not chunk-level filtering
                     if self.validate_chunk:
-                        sample = self.prepare_chunk(
-                            file_id,
-                            start_time,
-                            duration=self.duration,
-                        )
-                        if sample:
+                        idx_n = prepared_data["audio-metadata"][file_id].dtype.names.index("num_speakers")
+                        num_speakers = prepared_data["audio-metadata"][file_id][idx_n]
+                        if num_speakers <= self.max_speakers_per_chunk:
                             validation_chunks.append((file_id, start_time, self.duration))
                     else:
                         validation_chunks.append((file_id, start_time, self.duration))
-
-               
+                    unvalidated_chunks.append((file_id, start_time, self.duration))
+           
         dtype = [
             (
                 "file_id",
-                get_dtype(max(v[0] for v in validation_chunks)),
+                get_dtype(max(v[0] for v in unvalidated_chunks)),
             ),
             ("start", "f"),
             ("duration", "f"),
         ]
-
-        prepared_data["validation"] = np.array(validation_chunks, dtype=dtype) # important to make sure all prepared data are not None!
-        validation_chunks.clear()
+    
+        if len(validation_chunks) == 0:
+            warnings.warn(
+                "No file satisfies max_speakers_per_chunk in the validation set"
+                "using unvalidated chunks."
+            )
+            prepared_data["validation"] = np.array(unvalidated_chunks, dtype=dtype) 
+            validation_chunks.clear()
+            unvalidated_chunks.clear()
+        else:
+            prepared_data["validation"] = np.array(validation_chunks, dtype=dtype) # important to make sure all prepared data are not None!
+            validation_chunks.clear()
+            unvalidated_chunks.clear()
 
     def val__getitem__(self, idx):
         validation_chunk = self.prepared_data["validation"][idx]

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -138,10 +138,15 @@ class SegmentationTask(Task):
                 ]
                 start_time = rng.uniform(start, start + region_duration - duration)
                 sample = self.prepare_chunk(file_id, start_time, duration)
-                if sample: # only yield when satisfying less than max speakers 
+                # `sample` can be None when some task-specific condition is not meant
+                # (e.g. upper bound on the number of speakers in a chunk for the 
+                # segmentation task)
+                if sample: 
                     num_chunks += 1
                     yield sample 
-                else: #skip file if None   
+                # when `sample` is None, go to next file
+                # TODO: this might break training of tasks (e.g. PixIT) that expects a fixed (and greater than 1) number of chunks per file
+                else:    
                     num_chunks = num_chunks_per_file + 1
       
 

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -92,7 +92,6 @@ class SegmentationTask(Task):
             training &= self.prepared_data["audio-metadata"][key] == self.prepared_data[
                 "metadata"
             ][key].index(value)
-        file_ids = np.where(training)[0]
 
         # turn annotated duration into a probability distribution
         annotated_duration = self.prepared_data["audio-annotated"][file_ids]

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -315,7 +315,7 @@ class SegmentationTask(Task):
             validation_chunks.clear()
             unvalidated_chunks.clear()
         else:
-            prepared_data["validation"] = np.array(validation_chunks, dtype=dtype) # important to make sure all prepared data are not None!
+            prepared_data["validation"] = np.array(validation_chunks, dtype=dtype)
             validation_chunks.clear()
             unvalidated_chunks.clear()
 

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -296,7 +296,7 @@ class SegmentationTask(Task):
                     else:
                         validation_chunks.append((file_id, start_time, self.duration))
                     unvalidated_chunks.append((file_id, start_time, self.duration))
-           
+               
         dtype = [
             (
                 "file_id",

--- a/src/pyannote/audio/tasks/segmentation/mixins.py
+++ b/src/pyannote/audio/tasks/segmentation/mixins.py
@@ -25,6 +25,7 @@ import itertools
 import math
 import random
 from typing import Dict, Sequence, Union
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -290,7 +291,7 @@ class SegmentationTask(Task):
                     else:
                         validation_chunks.append((file_id, start_time, self.duration))
                     unvalidated_chunks.append((file_id, start_time, self.duration))
-           
+               
         dtype = [
             (
                 "file_id",

--- a/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -329,9 +329,8 @@ class SpeakerDiarization(SegmentationTask):
         labels = list(np.unique(chunk_annotations[label_scope_key]))
         num_labels = len(labels)
 
-        if num_labels > self.max_speakers_per_chunk:
-            if self.validate_chunk: 
-                return None # skip this chunk and return None. 
+        if num_labels > self.max_speakers_per_chunk and self.validate_chunk:
+            return None # skip this chunk and return None. 
 
         # initial frame-level targets
         num_frames = self.model.num_frames(

--- a/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -164,6 +164,7 @@ class SpeakerDiarization(SegmentationTask):
         self.max_speakers_per_frame = max_speakers_per_frame
         self.balance = balance
         self.weight = weight
+        self.validate_chunk = validate_chunk
 
     def setup(self, stage=None):
         super().setup(stage)

--- a/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -76,6 +76,8 @@ class SpeakerDiarization(SegmentationTask):
         Defaults to estimating it from the training set.
     max_speakers_per_frame : int, optional
         Maximum number of (overlapping) speakers per frame. Defaults to 2.
+    validate_chunk : bool, optional
+        if True, training and validation data will only include chunks with less than max_speakers_per_chunk. Defaults to None
     balance: Sequence[Text], optional
         When provided, training samples are sampled uniformly with respect to these keys.
         For instance, setting `balance` to ["database","subset"] will make sure that each
@@ -126,7 +128,7 @@ class SpeakerDiarization(SegmentationTask):
         max_num_speakers: Optional[
             int
         ] = None,  # deprecated in favor of `max_speakers_per_chunk``
-        validate_chunk: bool = False, # if validation data follows max_speakers_per_chunk
+        validate_chunk: bool = False, 
         loss: Literal["bce", "mse"] = None,  # deprecated
     ):
         super().__init__(

--- a/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/src/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -126,6 +126,7 @@ class SpeakerDiarization(SegmentationTask):
         max_num_speakers: Optional[
             int
         ] = None,  # deprecated in favor of `max_speakers_per_chunk``
+        validate_chunk: bool = False, # if validation data follows max_speakers_per_chunk
         loss: Literal["bce", "mse"] = None,  # deprecated
     ):
         super().__init__(
@@ -328,7 +329,8 @@ class SpeakerDiarization(SegmentationTask):
         num_labels = len(labels)
 
         if num_labels > self.max_speakers_per_chunk:
-            pass
+            if self.validate_chunk: 
+                return None # skip this chunk and return None. 
 
         # initial frame-level targets
         num_frames = self.model.num_frames(


### PR DESCRIPTION
A new flag `validate_chunk` (input to `SpeakerDiarization` class, defaults to `False`) will determine if chunk is skipped when exceeding `max_speakers_per_chunk`
3 changes if validate_chunk=True :

1. SpeakerDiarization.prepare_chunk can return None
2. SegmentationTask.train__iter__helper will skip current chunk if exceeding max number of speakers
3. SegmentationTask.prepare_validation will skip current chunk if exceeding max number of speakers. If none of the validation data satisfies criteria, it will return the full "unvalidated" validation set.