### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@ With the optional telemetry feature in `pyannote.audio`, you can choose to send 
 `pyannote.audio` does [speech separation](https://hf.co/pyannote/speech-separation-ami-1.0): multi-speaker audio in, one audio channel per speaker out!
 
 ```bash
-pip install pyannote.audio[separation]==3.3.0
+pip install 'pyannote.audio[separation]==3.3.0'
 ```
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ If you use `pyannote.audio` please use the following citations:
 The commands below will setup pre-commit hooks and packages needed for developing the `pyannote.audio` library.
 
 ```bash
-pip install -e .[dev,testing]
+pip install -e '.[dev,testing]'
 pre-commit install
 ```
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `CHANGELOG.md`
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`