### PR TITLE
feat(pipeline): extract speaker embeddings with one model call per chunk

### DIFF
--- a/src/pyannote/audio/core/inference.py
+++ b/src/pyannote/audio/core/inference.py
@@ -40,7 +40,14 @@ from pyannote.core import Segment, SlidingWindow, SlidingWindowFeature
 
 
 class BaseInference:
-    pass
+    @property
+    def supports_multi_speaker_masks(self) -> bool:
+        """Whether `__call__` supports (batch, speakers, frames)-shaped masks
+
+        When `True`, `__call__` accepts the masks of several speakers for the very same
+        batch of waveforms, and returns a (batch, speakers, dimension)-shaped array.
+        """
+        return False
 
 
 class Inference(BaseInference):

--- a/src/pyannote/audio/pipelines/speaker_diarization.py
+++ b/src/pyannote/audio/pipelines/speaker_diarization.py
@@ -370,7 +370,7 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
                 return cache["embeddings"]
 
         duration = binary_segmentations.sliding_window.duration
-        num_chunks, num_frames, num_speakers = binary_segmentations.data.shape
+        num_frames = binary_segmentations.data.shape[1]
 
         if exclude_overlap:
             # minimum number of samples needed to extract an embedding
@@ -395,6 +395,59 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
             clean_segmentations = SlidingWindowFeature(
                 binary_segmentations.data, binary_segmentations.sliding_window
             )
+
+        # masks are only used by the pooling layer of speaker embedding models: the
+        # (much more expensive) layers before it do not depend on them. For models that
+        # support it, we therefore run the model once per chunk with the masks of all
+        # its speakers at once, instead of once per (chunk, speaker) pair.
+        if self._embedding.supports_multi_speaker_masks:
+            embeddings = self._get_embeddings_per_chunk(
+                file,
+                binary_segmentations,
+                clean_segmentations,
+                min_num_frames,
+                hook=hook,
+            )
+        else:
+            embeddings = self._get_embeddings_per_pair(
+                file,
+                binary_segmentations,
+                clean_segmentations,
+                min_num_frames,
+                hook=hook,
+            )
+
+        # caching embeddings for subsequent trials
+        # (see comments at the top of this method for more details)
+        if self.training:
+            if self._segmentation.model.specifications.powerset:
+                file["training_cache/embeddings"] = {
+                    "embeddings": embeddings,
+                }
+            else:
+                file["training_cache/embeddings"] = {
+                    "segmentation.threshold": self.segmentation.threshold,
+                    "embeddings": embeddings,
+                }
+
+        return embeddings
+
+    def _get_embeddings_per_pair(
+        self,
+        file,
+        binary_segmentations: SlidingWindowFeature,
+        clean_segmentations: SlidingWindowFeature,
+        min_num_frames: int,
+        hook: Optional[Callable] = None,
+    ) -> np.ndarray:
+        """Extract embeddings with one model call per (chunk, speaker) pair
+
+        Returns
+        -------
+        embeddings : (num_chunks, num_speakers, dimension) array
+        """
+
+        num_chunks, _, num_speakers = binary_segmentations.data.shape
 
         def iter_waveform_and_mask():
             for (chunk, masks), (_, clean_masks) in zip(
@@ -460,20 +513,82 @@ class SpeakerDiarization(SpeakerDiarizationMixin, Pipeline):
 
         embedding_batches = np.vstack(embedding_batches)
 
-        embeddings = rearrange(embedding_batches, "(c s) d -> c s d", c=num_chunks)
+        return rearrange(embedding_batches, "(c s) d -> c s d", c=num_chunks)
 
-        # caching embeddings for subsequent trials
-        # (see comments at the top of this method for more details)
-        if self.training:
-            if self._segmentation.model.specifications.powerset:
-                file["training_cache/embeddings"] = {
-                    "embeddings": embeddings,
-                }
-            else:
-                file["training_cache/embeddings"] = {
-                    "segmentation.threshold": self.segmentation.threshold,
-                    "embeddings": embeddings,
-                }
+    def _get_embeddings_per_chunk(
+        self,
+        file,
+        binary_segmentations: SlidingWindowFeature,
+        clean_segmentations: SlidingWindowFeature,
+        min_num_frames: int,
+        hook: Optional[Callable] = None,
+    ) -> np.ndarray:
+        """Extract embeddings with one model call per chunk
+
+        Same output as `_get_embeddings_per_pair`, but relies on the embedding model
+        supporting (batch, speakers, frames)-shaped masks: everything but the pooling
+        layer is then computed once per chunk instead of once per (chunk, speaker) pair.
+
+        Returns
+        -------
+        embeddings : (num_chunks, num_speakers, dimension) array
+        """
+
+        num_chunks, _, num_speakers = binary_segmentations.data.shape
+        chunks = binary_segmentations.sliding_window
+
+        # `embedding_batch_size` keeps counting (chunk, speaker) pairs, so that peak
+        # memory does not depend on which of the two implementations is used
+        batch_size = max(1, self.embedding_batch_size // num_speakers)
+        batch_count = math.ceil(num_chunks / batch_size)
+
+        embeddings = np.empty(
+            (num_chunks, num_speakers, self._embedding.dimension), dtype=np.float32
+        )
+
+        if hook is not None:
+            hook("embeddings", None, total=batch_count, completed=0)
+
+        for i, start in enumerate(range(0, num_chunks, batch_size), 1):
+            stop = min(start + batch_size, num_chunks)
+
+            waveform_batch = torch.vstack(
+                [
+                    self._audio.crop(file, chunks[c], mode="pad")[0][None]
+                    for c in range(start, stop)
+                ]
+            )
+            # (batch_size, 1, num_samples) torch.Tensor
+
+            # masks may contain NaN (in case of partial stitching)
+            masks = np.nan_to_num(binary_segmentations.data[start:stop], nan=0.0)
+            clean_masks = np.nan_to_num(clean_segmentations.data[start:stop], nan=0.0)
+
+            # use clean (non-overlapping) speech when there is enough of it
+            used_masks = np.where(
+                np.sum(clean_masks, axis=1, keepdims=True) > min_num_frames,
+                clean_masks,
+                masks,
+            )
+            mask_batch = torch.from_numpy(
+                np.ascontiguousarray(used_masks.transpose(0, 2, 1), dtype=np.float32)
+            )
+            # (batch_size, num_speakers, num_frames) torch.Tensor
+
+            embedding_batch: np.ndarray = self._embedding(
+                waveform_batch, masks=mask_batch
+            )
+            # (batch_size, num_speakers, dimension) np.ndarray
+
+            embeddings[start:stop] = embedding_batch
+
+            if hook is not None:
+                hook(
+                    "embeddings",
+                    rearrange(embedding_batch, "c s d -> (c s) d"),
+                    total=batch_count,
+                    completed=i,
+                )
 
         return embeddings
 

--- a/src/pyannote/audio/pipelines/speaker_verification.py
+++ b/src/pyannote/audio/pipelines/speaker_verification.py
@@ -701,6 +701,26 @@ class PyannoteAudioPretrainedSpeakerEmbedding(BaseInference):
 
         return upper
 
+    @cached_property
+    def supports_multi_speaker_masks(self) -> bool:
+        """Whether the wrapped model supports (batch, speakers, frames)-shaped masks
+
+        Models pooling with `StatsPool` do, but layers sitting after the pooling layer
+        may not be agnostic to the extra dimension. Rather than enumerating model
+        classes, run the model once and look at the shape of its output.
+        """
+        with torch.inference_mode(), warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                embeddings = self.model_(
+                    torch.randn(1, 1, self.sample_rate).to(self.device),
+                    weights=torch.ones(1, 2, 16).to(self.device),
+                )
+            except Exception:
+                return False
+
+        return tuple(embeddings.shape) == (1, 2, self.dimension)
+
     def __call__(
         self, waveforms: torch.Tensor, masks: Optional[torch.Tensor] = None
     ) -> np.ndarray:

--- a/tests/test_speaker_embedding_masks.py
+++ b/tests/test_speaker_embedding_masks.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+import torch
+
+from pyannote.audio.models.embedding import WeSpeakerResNet34
+from pyannote.audio.pipelines.speaker_verification import (
+    PyannoteAudioPretrainedSpeakerEmbedding,
+)
+
+NUM_SAMPLES = 16000
+NUM_FRAMES = 100
+
+
+@pytest.fixture(scope="module")
+def embedding():
+    torch.manual_seed(0)
+    return PyannoteAudioPretrainedSpeakerEmbedding(WeSpeakerResNet34())
+
+
+@pytest.fixture(scope="module")
+def batch():
+    torch.manual_seed(1)
+    waveforms = torch.randn(2, 1, NUM_SAMPLES)
+    masks = (torch.rand(2, 3, NUM_FRAMES) > 0.5).float()
+    # make sure no mask is empty
+    masks[:, :, :10] = 1.0
+    return waveforms, masks
+
+
+def test_supports_multi_speaker_masks(embedding):
+    assert embedding.supports_multi_speaker_masks
+
+
+def test_multi_speaker_masks_match_one_speaker_at_a_time(embedding, batch):
+    """One call with all speakers must return what several calls would return"""
+
+    waveforms, masks = batch
+
+    together = embedding(waveforms, masks=masks)
+    assert together.shape == (2, 3, embedding.dimension)
+
+    apart = np.stack(
+        [embedding(waveforms, masks=masks[:, speaker]) for speaker in range(3)],
+        axis=1,
+    )
+    # (2, 3, dimension)
+
+    np.testing.assert_allclose(together, apart, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
### What

`get_embeddings` calls the embedding model once per (chunk, speaker) pair, feeding it
the same waveform `num_speakers` times. Masks only matter to the pooling layer, so
everything before it is computed `num_speakers` times and discarded `num_speakers - 1`
times.

This PR calls the model once per chunk with the masks of all its speakers at once, for
embedding models that support it. Output is unchanged.

### How

- `BaseInference.supports_multi_speaker_masks` (defaults to `False`) tells whether
  `__call__` accepts `(batch, speakers, frames)`-shaped masks.
- `PyannoteAudioPretrainedSpeakerEmbedding` answers it by running the model once on a
  dummy batch and checking the output shape, the same way `min_num_samples` probes the
  model. This covers models whose post-pooling layers are not agnostic to the extra
  dimension, without having to enumerate model classes.
- `get_embeddings` picks `_get_embeddings_per_chunk` when supported and
  `_get_embeddings_per_pair` (the current code, moved as is) otherwise.
- `embedding_batch_size` keeps counting (chunk, speaker) pairs, so peak memory does not
  depend on which implementation runs.
- SpeechBrain, NeMo and ONNX WeSpeaker wrappers keep the current behaviour: their
  `__call__` takes 2-dimensional masks, the probe returns `False` for them.

### Results

The number of forward passes through the embedding model drops exactly
`num_speakers`-fold: 333 → 111 for the file below.

`pyannote/speaker-diarization-community-1`, this repo's `sample.wav` repeated 4× (120s),
preloaded as a waveform, `pyannote.audio` 4.0.7 + torch 2.13, Apple M3 laptop, medians
of 3 runs across several invocations:

| device | embeddings step | whole pipeline | output |
|---|---|---|---|
| cpu | ×3.7–4.8 | ×3.1–4.1 | identical |
| mps | ×2.6–2.8 | ×2.4–2.7 | identical |

### Tests

`tests/test_speaker_embedding_masks.py` builds a `WeSpeakerResNet34` (no download) and
checks that one call with `(batch, speakers, frames)` masks returns what several
one-speaker calls return, plus that the capability probe answers `True` for it.

```
tests/test_speaker_embedding_masks.py ..                       [100%]
2 passed
```

`test_stats_pool.py`, `test_clustering.py`, `test_sample.py` and `test_import_lib.py`
also pass locally.